### PR TITLE
Implement config savegame editing & Service::CFG clean up

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SRCS
             configure_debug.cpp
             configure_dialog.cpp
             configure_general.cpp
+            configure_system.cpp
             game_list.cpp
             hotkeys.cpp
             main.cpp
@@ -52,6 +53,7 @@ set(HEADERS
             configure_debug.h
             configure_dialog.h
             configure_general.h
+            configure_system.h
             game_list.h
             game_list_p.h
             hotkeys.h
@@ -69,6 +71,7 @@ set(UIS
             configure_audio.ui
             configure_debug.ui
             configure_general.ui
+            configure_system.ui
             hotkeys.ui
             main.ui
             )

--- a/src/citra_qt/configure.ui
+++ b/src/citra_qt/configure.ui
@@ -24,6 +24,11 @@
        <string>General</string>
       </attribute>
      </widget>
+     <widget class="ConfigureSystem" name="systemTab">
+      <attribute name="title">
+       <string>System</string>
+      </attribute>
+     </widget>
      <widget class="QWidget" name="inputTab">
       <attribute name="title">
        <string>Input</string>
@@ -55,6 +60,12 @@
    <class>ConfigureGeneral</class>
    <extends>QWidget</extends>
    <header>configure_general.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConfigureSystem</class>
+   <extends>QWidget</extends>
+   <header>configure_system.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/citra_qt/configure_dialog.cpp
+++ b/src/citra_qt/configure_dialog.cpp
@@ -9,9 +9,10 @@
 
 #include "core/settings.h"
 
-ConfigureDialog::ConfigureDialog(QWidget *parent) :
+ConfigureDialog::ConfigureDialog(QWidget *parent, bool running) :
     QDialog(parent),
-    ui(new Ui::ConfigureDialog)
+    ui(new Ui::ConfigureDialog),
+    emulation_running(running)
 {
     ui->setupUi(this);
     this->setConfiguration();
@@ -21,10 +22,15 @@ ConfigureDialog::~ConfigureDialog() {
 }
 
 void ConfigureDialog::setConfiguration() {
+
+    // System tab needs set manually
+    // depending on whether emulation is running
+    ui->systemTab->setConfiguration(emulation_running);
 }
 
 void ConfigureDialog::applyConfiguration() {
     ui->generalTab->applyConfiguration();
+    ui->systemTab->applyConfiguration();
     ui->audioTab->applyConfiguration();
     ui->debugTab->applyConfiguration();
 }

--- a/src/citra_qt/configure_dialog.h
+++ b/src/citra_qt/configure_dialog.h
@@ -16,7 +16,7 @@ class ConfigureDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ConfigureDialog(QWidget *parent = nullptr);
+    explicit ConfigureDialog(QWidget *parent, bool emulation_running);
     ~ConfigureDialog();
 
     void applyConfiguration();
@@ -26,4 +26,5 @@ private:
 
 private:
     std::unique_ptr<Ui::ConfigureDialog> ui;
+    bool emulation_running;
 };

--- a/src/citra_qt/configure_system.cpp
+++ b/src/citra_qt/configure_system.cpp
@@ -1,0 +1,113 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "citra_qt/configure_system.h"
+#include "citra_qt/ui_settings.h"
+#include "ui_configure_system.h"
+
+#include "core/hle/service/fs/archive.h"
+#include "core/hle/service/cfg/cfg.h"
+
+ConfigureSystem::ConfigureSystem(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::ConfigureSystem) {
+    ui->setupUi(this);
+
+    // Limits the username length.
+    // setMaxLength seems to count characters in char16_t,
+    // which is what we need because we want to limit the name
+    // to 20 bytes.
+    ui->edit_username->setMaxLength(10);
+
+    // Add days to the birthday combo box
+    for (int i = 1; i <= 31; ++i) {
+        ui->combo_birthday->addItem(QString::number(i));
+    }
+}
+
+ConfigureSystem::~ConfigureSystem() {
+}
+
+void ConfigureSystem::setConfiguration(bool emulation_running) {
+    this->enabled = !emulation_running;
+
+    if (!enabled) {
+        ui->group_system_settings->setEnabled(false);
+    }
+    else {
+        ui->group_system_settings->setEnabled(true);
+
+        // This tab is enabled only when game is not running (i.e. all service are not initialized).
+        // Temporarily register archive types and load the config savegame file to memory.
+        Service::FS::RegisterArchiveTypes();
+        ResultCode result = Service::CFG::LoadConfigNANDSaveFile();
+        Service::FS::UnregisterArchiveTypes();
+
+        if (result.IsError()) {
+            ui->label_disable_info->setText(tr("Failed to load system settings data"));
+            ui->group_system_settings->setEnabled(false);
+            this->enabled = false;
+            return;
+        }
+
+        // set username
+        username = Service::CFG::GetUsername();
+        ui->edit_username->setText(QString::fromStdU16String(username));
+
+        // set birthday
+        std::tie(birthmonth, birthday) = Service::CFG::GetBirthday();
+        ui->combo_birthmonth->setCurrentIndex(birthmonth - 1);
+        ui->combo_birthday->setCurrentIndex(birthday - 1);
+
+        // set system language
+        language_index = Service::CFG::GetSystemLanguage();
+        ui->combo_language->setCurrentIndex(language_index);
+
+        // set sound output mode
+        sound_index = Service::CFG::GetSoundOutputMode();
+        ui->combo_sound->setCurrentIndex(sound_index);
+
+        ui->label_disable_info->hide();
+    }
+}
+
+void ConfigureSystem::applyConfiguration() {
+    if (!enabled)
+        return;
+
+    bool modified = false;
+
+    // apply username
+    std::u16string new_username = ui->edit_username->text().toStdU16String();
+    if (new_username != username) {
+        Service::CFG::SetUsername(new_username);
+        modified = true;
+    }
+
+    // apply birthday
+    int new_birthmonth = ui->combo_birthmonth->currentIndex() + 1;
+    int new_birthday = ui->combo_birthday->currentIndex() + 1;
+    if (birthmonth != new_birthmonth || birthday != new_birthday) {
+        Service::CFG::SetBirthday(new_birthmonth, new_birthday);
+        modified = true;
+    }
+
+    // apply language
+    int new_language = ui->combo_language->currentIndex();
+    if (language_index != new_language) {
+        Service::CFG::SetSystemLanguage(static_cast<Service::CFG::SystemLanguage>(new_language));
+        modified = true;
+    }
+
+    // apply sound
+    int new_sound = ui->combo_sound->currentIndex();
+    if (sound_index != new_sound) {
+        Service::CFG::SetSoundOutputMode(static_cast<Service::CFG::SoundOutputMode>(new_sound));
+        modified = true;
+    }
+
+    // update the config savegame if any item is modified.
+    if (modified)
+        Service::CFG::UpdateConfigNANDSavegame();
+}

--- a/src/citra_qt/configure_system.h
+++ b/src/citra_qt/configure_system.h
@@ -1,0 +1,33 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QWidget>
+
+namespace Ui {
+class ConfigureSystem;
+}
+
+class ConfigureSystem : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ConfigureSystem(QWidget *parent = nullptr);
+    ~ConfigureSystem();
+
+    void applyConfiguration();
+    void setConfiguration(bool emulation_running);
+
+private:
+    std::unique_ptr<Ui::ConfigureSystem> ui;
+    bool enabled;
+
+    std::u16string username;
+    int birthmonth, birthday;
+    int language_index;
+    int sound_index;
+};

--- a/src/citra_qt/configure_system.ui
+++ b/src/citra_qt/configure_system.ui
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureSystem</class>
+ <widget class="QWidget" name="ConfigureSystem">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>377</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QGroupBox" name="group_system_settings">
+       <property name="title">
+        <string>System Settings</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_username">
+          <item>
+           <widget class="QLabel" name="label_username">
+            <property name="text">
+             <string>Username</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="edit_username">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_birthday">
+          <item>
+           <widget class="QLabel" name="label_birthday">
+            <property name="text">
+             <string>Birthday</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_birthday2">
+            <item>
+             <widget class="QComboBox" name="combo_birthmonth">
+              <item>
+               <property name="text">
+                <string>January</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>February</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>March</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>April</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>May</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>June</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>July</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>August</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>September</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>October</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>November</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>December</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="combo_birthday"/>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_language">
+          <item>
+           <widget class="QLabel" name="label_language">
+            <property name="text">
+             <string>Language</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="combo_language">
+            <item>
+             <property name="text">
+              <string>Japanese (日本語)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>English</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>French (français)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>German (Deutsch)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Italian (italiano)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Spanish (español)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Simplified Chinese (简体中文)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Korean (한국어)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Dutch (Nederlands)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Portuguese (português)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Russian (Русский)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Traditional Chinese (正體中文)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_sound">
+          <item>
+           <widget class="QLabel" name="label_sound">
+            <property name="text">
+             <string>Sound output mode</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="combo_sound">
+            <item>
+             <property name="text">
+              <string>Mono</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Stereo</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Surround</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_disable_info">
+       <property name="text">
+        <string>System settings are available only when game is not running.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>238</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -508,7 +508,7 @@ void GMainWindow::ToggleWindowMode() {
 }
 
 void GMainWindow::OnConfigure() {
-    ConfigureDialog configureDialog(this);
+    ConfigureDialog configureDialog(this, emulation_running);
     auto result = configureDialog.exec();
     if (result == QDialog::Accepted)
     {

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -73,8 +73,7 @@ static const ConsoleModelInfo CONSOLE_MODEL = { NINTENDO_3DS_XL, { 0, 0, 0 } };
 static const u8 CONSOLE_LANGUAGE = LANGUAGE_EN;
 static const UsernameBlock CONSOLE_USERNAME_BLOCK = { u"CITRA", 0, 0 };
 static const BirthdayBlock PROFILE_BIRTHDAY = { 3, 25 }; // March 25th, 2014
-/// TODO(Subv): Find out what this actually is
-static const u8 SOUND_OUTPUT_MODE = 2;
+static const u8 SOUND_OUTPUT_MODE = SOUND_SURROUND;
 static const u8 UNITED_STATES_COUNTRY_ID = 49;
 /// TODO(Subv): Find what the other bytes are
 static const ConsoleCountryInfo COUNTRY_INFO = { { 0, 0, 0 }, UNITED_STATES_COUNTRY_ID };

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -223,6 +223,22 @@ void GetConfigInfoBlk8(Service::Interface* self) {
     Memory::WriteBlock(data_pointer, data.data(), data.size());
 }
 
+void SetConfigInfoBlk4(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+    u32 block_id = cmd_buff[1];
+    u32 size = cmd_buff[2];
+    VAddr data_pointer = cmd_buff[4];
+
+    if (!Memory::IsValidVirtualAddress(data_pointer)) {
+        cmd_buff[1] = -1; // TODO(Subv): Find the right error code
+        return;
+    }
+
+    std::vector<u8> data(size);
+    Memory::ReadBlock(data_pointer, data.data(), data.size());
+    cmd_buff[1] = Service::CFG::SetConfigInfoBlock(block_id, size, 0x4, data.data()).raw;
+}
+
 void UpdateConfigNANDSavegame(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     cmd_buff[1] = Service::CFG::UpdateConfigNANDSavegame().raw;
@@ -233,13 +249,13 @@ void FormatConfig(Service::Interface* self) {
     cmd_buff[1] = Service::CFG::FormatConfig().raw;
 }
 
-ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, u8* output) {
+static ResultVal<void*> GetConfigInfoBlockPointer(u32 block_id, u32 size, u32 flag) {
     // Read the header
     SaveFileConfig* config = reinterpret_cast<SaveFileConfig*>(cfg_config_file_buffer.data());
 
     auto itr = std::find_if(std::begin(config->block_entries), std::end(config->block_entries),
         [&](const SaveConfigBlockEntry& entry) {
-            return entry.block_id == block_id && (entry.flags & flag);
+            return entry.block_id == block_id;
         });
 
     if (itr == std::end(config->block_entries)) {
@@ -247,17 +263,38 @@ ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, u8* output) {
         return ResultCode(ErrorDescription::NotFound, ErrorModule::Config, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
     }
 
+    if ((itr->flags & flag) == 0) {
+        LOG_ERROR(Service_CFG, "Invalid flag %u for config block 0x%X with size %u", flag, block_id, size);
+        return ResultCode(ErrorDescription::NotAuthorized, ErrorModule::Config, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+    }
+
     if (itr->size != size) {
         LOG_ERROR(Service_CFG, "Invalid size %u for config block 0x%X with flags %u", size, block_id, flag);
         return ResultCode(ErrorDescription::InvalidSize, ErrorModule::Config, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
     }
 
+    void* pointer;
+
     // The data is located in the block header itself if the size is less than 4 bytes
     if (itr->size <= 4)
-        memcpy(output, &itr->offset_or_data, itr->size);
+        pointer = &itr->offset_or_data;
     else
-        memcpy(output, &cfg_config_file_buffer[itr->offset_or_data], itr->size);
+        pointer = &cfg_config_file_buffer[itr->offset_or_data];
 
+    return ResultVal<void*>::WithCode(RESULT_SUCCESS, pointer);
+}
+
+ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, void* output) {
+    void* pointer;
+    CASCADE_RESULT(pointer, GetConfigInfoBlockPointer(block_id, size, flag));
+    memcpy(output, pointer, size);
+    return RESULT_SUCCESS;
+}
+
+ResultCode SetConfigInfoBlock(u32 block_id, u32 size, u32 flag, void* input) {
+    void* pointer;
+    CASCADE_RESULT(pointer, GetConfigInfoBlockPointer(block_id, size, flag));
+    memcpy(pointer, input, size);
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -40,6 +40,20 @@ struct SaveFileConfig {
 };
 static_assert(sizeof(SaveFileConfig) == 0x455C, "SaveFileConfig header must be exactly 0x455C bytes");
 
+enum ConfigBlockID {
+    StereoCameraSettingsBlockID = 0x00050005,
+    SoundOutputModeBlockID = 0x00070001,
+    ConsoleUniqueIDBlockID = 0x00090001,
+    UsernameBlockID = 0x000A0000,
+    BirthdayBlockID = 0x000A0001,
+    LanguageBlockID = 0x000A0002,
+    CountryInfoBlockID = 0x000B0000,
+    CountryNameBlockID = 0x000B0001,
+    StateNameBlockID = 0x000B0002,
+    EULAVersionBlockID = 0x000D0000,
+    ConsoleModelBlockID = 0x000F0004,
+};
+
 struct UsernameBlock {
     char16_t username[10]; ///< Exactly 20 bytes long, padded with zeros at the end if necessary
     u32 zero;
@@ -372,25 +386,25 @@ ResultCode FormatConfig() {
     res = CreateConfigInfoBlk(0x00030001, 0x8, 0xE, zero_buffer);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(0x00050005, sizeof(STEREO_CAMERA_SETTINGS), 0xE, STEREO_CAMERA_SETTINGS.data());
+    res = CreateConfigInfoBlk(StereoCameraSettingsBlockID, sizeof(STEREO_CAMERA_SETTINGS), 0xE, STEREO_CAMERA_SETTINGS.data());
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(0x00070001, sizeof(SOUND_OUTPUT_MODE), 0xE, &SOUND_OUTPUT_MODE);
+    res = CreateConfigInfoBlk(SoundOutputModeBlockID, sizeof(SOUND_OUTPUT_MODE), 0xE, &SOUND_OUTPUT_MODE);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(0x00090001, sizeof(CONSOLE_UNIQUE_ID), 0xE, &CONSOLE_UNIQUE_ID);
+    res = CreateConfigInfoBlk(ConsoleUniqueIDBlockID, sizeof(CONSOLE_UNIQUE_ID), 0xE, &CONSOLE_UNIQUE_ID);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(0x000A0000, sizeof(CONSOLE_USERNAME_BLOCK), 0xE, &CONSOLE_USERNAME_BLOCK);
+    res = CreateConfigInfoBlk(UsernameBlockID, sizeof(CONSOLE_USERNAME_BLOCK), 0xE, &CONSOLE_USERNAME_BLOCK);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(0x000A0001, sizeof(PROFILE_BIRTHDAY), 0xE, &PROFILE_BIRTHDAY);
+    res = CreateConfigInfoBlk(BirthdayBlockID, sizeof(PROFILE_BIRTHDAY), 0xE, &PROFILE_BIRTHDAY);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(0x000A0002, sizeof(CONSOLE_LANGUAGE), 0xE, &CONSOLE_LANGUAGE);
+    res = CreateConfigInfoBlk(LanguageBlockID, sizeof(CONSOLE_LANGUAGE), 0xE, &CONSOLE_LANGUAGE);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(0x000B0000, sizeof(COUNTRY_INFO), 0xE, &COUNTRY_INFO);
+    res = CreateConfigInfoBlk(CountryInfoBlockID, sizeof(COUNTRY_INFO), 0xE, &COUNTRY_INFO);
     if (!res.IsSuccess()) return res;
 
     u16_le country_name_buffer[16][0x40] = {};
@@ -399,10 +413,10 @@ ResultCode FormatConfig() {
         std::copy(region_name.cbegin(), region_name.cend(), country_name_buffer[i]);
     }
     // 0x000B0001 - Localized names for the profile Country
-    res = CreateConfigInfoBlk(0x000B0001, sizeof(country_name_buffer), 0xE, country_name_buffer);
+    res = CreateConfigInfoBlk(CountryNameBlockID, sizeof(country_name_buffer), 0xE, country_name_buffer);
     if (!res.IsSuccess()) return res;
     // 0x000B0002 - Localized names for the profile State/Province
-    res = CreateConfigInfoBlk(0x000B0002, sizeof(country_name_buffer), 0xE, country_name_buffer);
+    res = CreateConfigInfoBlk(StateNameBlockID, sizeof(country_name_buffer), 0xE, country_name_buffer);
     if (!res.IsSuccess()) return res;
 
     // 0x000B0003 - Unknown, related to country/address (zip code?)
@@ -418,10 +432,10 @@ ResultCode FormatConfig() {
     if (!res.IsSuccess()) return res;
 
     // 0x000D0000 - Accepted EULA version
-    res = CreateConfigInfoBlk(0x000D0000, 0x4, 0xE, zero_buffer);
+    res = CreateConfigInfoBlk(EULAVersionBlockID, 0x4, 0xE, zero_buffer);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(0x000F0004, sizeof(CONSOLE_MODEL), 0xC, &CONSOLE_MODEL);
+    res = CreateConfigInfoBlk(ConsoleModelBlockID, sizeof(CONSOLE_MODEL), 0xC, &CONSOLE_MODEL);
     if (!res.IsSuccess()) return res;
 
     // 0x00170000 - Unknown

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -205,7 +205,7 @@ void GetModelNintendo2DS(Service::Interface* self) {
         cmd_buff[2] = 1;
 }
 
-void GetConfigInfoBlk2(Service::Interface* self) {
+void GetConfigInfoBlkUser(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 size = cmd_buff[1];
     u32 block_id = cmd_buff[2];
@@ -217,11 +217,11 @@ void GetConfigInfoBlk2(Service::Interface* self) {
     }
 
     std::vector<u8> data(size);
-    cmd_buff[1] = Service::CFG::GetConfigInfoBlock(block_id, size, 0x2, data.data()).raw;
+    cmd_buff[1] = Service::CFG::GetConfigInfoBlock(block_id, size, false, data.data()).raw;
     Memory::WriteBlock(data_pointer, data.data(), data.size());
 }
 
-void GetConfigInfoBlk8(Service::Interface* self) {
+void GetConfigInfoBlkSystem(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 size = cmd_buff[1];
     u32 block_id = cmd_buff[2];
@@ -233,11 +233,11 @@ void GetConfigInfoBlk8(Service::Interface* self) {
     }
 
     std::vector<u8> data(size);
-    cmd_buff[1] = Service::CFG::GetConfigInfoBlock(block_id, size, 0x8, data.data()).raw;
+    cmd_buff[1] = Service::CFG::GetConfigInfoBlock(block_id, size, true, data.data()).raw;
     Memory::WriteBlock(data_pointer, data.data(), data.size());
 }
 
-void SetConfigInfoBlk4(Service::Interface* self) {
+void SetConfigInfoBlkSystem(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 block_id = cmd_buff[1];
     u32 size = cmd_buff[2];
@@ -250,7 +250,7 @@ void SetConfigInfoBlk4(Service::Interface* self) {
 
     std::vector<u8> data(size);
     Memory::ReadBlock(data_pointer, data.data(), data.size());
-    cmd_buff[1] = Service::CFG::SetConfigInfoBlock(block_id, size, 0x4, data.data()).raw;
+    cmd_buff[1] = Service::CFG::SetConfigInfoBlock(block_id, size, true, data.data()).raw;
 }
 
 void UpdateConfigNANDSavegame(Service::Interface* self) {
@@ -263,7 +263,11 @@ void FormatConfig(Service::Interface* self) {
     cmd_buff[1] = Service::CFG::FormatConfig().raw;
 }
 
-static ResultVal<void*> GetConfigInfoBlockPointer(u32 block_id, u32 size, u32 flag) {
+static bool CheckPermission(ConfigPermission permissions, ConfigPermission request) {
+    return (static_cast<u16>(permissions) & static_cast<u16>(request)) != 0;
+}
+
+static ResultVal<void*> GetConfigInfoBlockPointer(u32 block_id, u32 size, ConfigPermission permission) {
     // Read the header
     SaveFileConfig* config = reinterpret_cast<SaveFileConfig*>(cfg_config_file_buffer.data());
 
@@ -273,17 +277,17 @@ static ResultVal<void*> GetConfigInfoBlockPointer(u32 block_id, u32 size, u32 fl
         });
 
     if (itr == std::end(config->block_entries)) {
-        LOG_ERROR(Service_CFG, "Config block 0x%X with flags %u and size %u was not found", block_id, flag, size);
+        LOG_ERROR(Service_CFG, "Config block 0x%X with permission %u and size %u was not found", block_id, static_cast<u16>(permission), size);
         return ResultCode(ErrorDescription::NotFound, ErrorModule::Config, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
     }
 
-    if ((itr->flags & flag) == 0) {
-        LOG_ERROR(Service_CFG, "Invalid flag %u for config block 0x%X with size %u", flag, block_id, size);
+    if (!CheckPermission(itr->permissions, permission)) {
+        LOG_ERROR(Service_CFG, "Invalid permission %u for config block 0x%X with size %u", static_cast<u16>(permission), block_id, size);
         return ResultCode(ErrorDescription::NotAuthorized, ErrorModule::Config, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
     }
 
     if (itr->size != size) {
-        LOG_ERROR(Service_CFG, "Invalid size %u for config block 0x%X with flags %u", size, block_id, flag);
+        LOG_ERROR(Service_CFG, "Invalid size %u for config block 0x%X with permission %u", size, block_id, static_cast<u16>(permission));
         return ResultCode(ErrorDescription::InvalidSize, ErrorModule::Config, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
     }
 
@@ -298,27 +302,29 @@ static ResultVal<void*> GetConfigInfoBlockPointer(u32 block_id, u32 size, u32 fl
     return ResultVal<void*>::WithCode(RESULT_SUCCESS, pointer);
 }
 
-ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, void* output) {
+ResultCode GetConfigInfoBlock(u32 block_id, u32 size, bool system_permission, void* output) {
     void* pointer;
-    CASCADE_RESULT(pointer, GetConfigInfoBlockPointer(block_id, size, flag));
+    CASCADE_RESULT(pointer, GetConfigInfoBlockPointer(block_id, size,
+        system_permission ? ConfigPermission::SystemRead : ConfigPermission::UserRead));
     memcpy(output, pointer, size);
     return RESULT_SUCCESS;
 }
 
-ResultCode SetConfigInfoBlock(u32 block_id, u32 size, u32 flag, void* input) {
+ResultCode SetConfigInfoBlock(u32 block_id, u32 size, bool system_permission, void* input) {
     void* pointer;
-    CASCADE_RESULT(pointer, GetConfigInfoBlockPointer(block_id, size, flag));
+    CASCADE_RESULT(pointer, GetConfigInfoBlockPointer(block_id, size,
+        system_permission ? ConfigPermission::SystemWrite : ConfigPermission::UserWrite));
     memcpy(pointer, input, size);
     return RESULT_SUCCESS;
 }
 
-ResultCode CreateConfigInfoBlk(u32 block_id, u16 size, u16 flags, const void* data) {
+ResultCode CreateConfigInfoBlk(u32 block_id, u16 size, ConfigPermission permissions, const void* data) {
     SaveFileConfig* config = reinterpret_cast<SaveFileConfig*>(cfg_config_file_buffer.data());
     if (config->total_entries >= CONFIG_FILE_MAX_BLOCK_ENTRIES)
         return ResultCode(-1); // TODO(Subv): Find the right error code
 
     // Insert the block header with offset 0 for now
-    config->block_entries[config->total_entries] = { block_id, 0, size, flags };
+    config->block_entries[config->total_entries] = { block_id, 0, size, permissions };
     if (size > 4) {
         u32 offset = config->data_entries_offset;
         // Perform a search to locate the next offset for the new data
@@ -383,28 +389,28 @@ ResultCode FormatConfig() {
     u8 zero_buffer[0xC0] = {};
 
     // 0x00030001 - Unknown
-    res = CreateConfigInfoBlk(0x00030001, 0x8, 0xE, zero_buffer);
+    res = CreateConfigInfoBlk(0x00030001, 0x8, ConfigPermission::Public, zero_buffer);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(StereoCameraSettingsBlockID, sizeof(STEREO_CAMERA_SETTINGS), 0xE, STEREO_CAMERA_SETTINGS.data());
+    res = CreateConfigInfoBlk(StereoCameraSettingsBlockID, sizeof(STEREO_CAMERA_SETTINGS), ConfigPermission::Public, STEREO_CAMERA_SETTINGS.data());
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(SoundOutputModeBlockID, sizeof(SOUND_OUTPUT_MODE), 0xE, &SOUND_OUTPUT_MODE);
+    res = CreateConfigInfoBlk(SoundOutputModeBlockID, sizeof(SOUND_OUTPUT_MODE), ConfigPermission::Public, &SOUND_OUTPUT_MODE);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(ConsoleUniqueIDBlockID, sizeof(CONSOLE_UNIQUE_ID), 0xE, &CONSOLE_UNIQUE_ID);
+    res = CreateConfigInfoBlk(ConsoleUniqueIDBlockID, sizeof(CONSOLE_UNIQUE_ID), ConfigPermission::Public, &CONSOLE_UNIQUE_ID);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(UsernameBlockID, sizeof(CONSOLE_USERNAME_BLOCK), 0xE, &CONSOLE_USERNAME_BLOCK);
+    res = CreateConfigInfoBlk(UsernameBlockID, sizeof(CONSOLE_USERNAME_BLOCK), ConfigPermission::Public, &CONSOLE_USERNAME_BLOCK);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(BirthdayBlockID, sizeof(PROFILE_BIRTHDAY), 0xE, &PROFILE_BIRTHDAY);
+    res = CreateConfigInfoBlk(BirthdayBlockID, sizeof(PROFILE_BIRTHDAY), ConfigPermission::Public, &PROFILE_BIRTHDAY);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(LanguageBlockID, sizeof(CONSOLE_LANGUAGE), 0xE, &CONSOLE_LANGUAGE);
+    res = CreateConfigInfoBlk(LanguageBlockID, sizeof(CONSOLE_LANGUAGE), ConfigPermission::Public, &CONSOLE_LANGUAGE);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(CountryInfoBlockID, sizeof(COUNTRY_INFO), 0xE, &COUNTRY_INFO);
+    res = CreateConfigInfoBlk(CountryInfoBlockID, sizeof(COUNTRY_INFO), ConfigPermission::Public, &COUNTRY_INFO);
     if (!res.IsSuccess()) return res;
 
     u16_le country_name_buffer[16][0x40] = {};
@@ -413,33 +419,33 @@ ResultCode FormatConfig() {
         std::copy(region_name.cbegin(), region_name.cend(), country_name_buffer[i]);
     }
     // 0x000B0001 - Localized names for the profile Country
-    res = CreateConfigInfoBlk(CountryNameBlockID, sizeof(country_name_buffer), 0xE, country_name_buffer);
+    res = CreateConfigInfoBlk(CountryNameBlockID, sizeof(country_name_buffer), ConfigPermission::Public, country_name_buffer);
     if (!res.IsSuccess()) return res;
     // 0x000B0002 - Localized names for the profile State/Province
-    res = CreateConfigInfoBlk(StateNameBlockID, sizeof(country_name_buffer), 0xE, country_name_buffer);
+    res = CreateConfigInfoBlk(StateNameBlockID, sizeof(country_name_buffer), ConfigPermission::Public, country_name_buffer);
     if (!res.IsSuccess()) return res;
 
     // 0x000B0003 - Unknown, related to country/address (zip code?)
-    res = CreateConfigInfoBlk(0x000B0003, 0x4, 0xE, zero_buffer);
+    res = CreateConfigInfoBlk(0x000B0003, 0x4, ConfigPermission::Public, zero_buffer);
     if (!res.IsSuccess()) return res;
 
     // 0x000C0000 - Unknown
-    res = CreateConfigInfoBlk(0x000C0000, 0xC0, 0xE, zero_buffer);
+    res = CreateConfigInfoBlk(0x000C0000, 0xC0, ConfigPermission::Public, zero_buffer);
     if (!res.IsSuccess()) return res;
 
     // 0x000C0001 - Unknown
-    res = CreateConfigInfoBlk(0x000C0001, 0x14, 0xE, zero_buffer);
+    res = CreateConfigInfoBlk(0x000C0001, 0x14, ConfigPermission::Public, zero_buffer);
     if (!res.IsSuccess()) return res;
 
     // 0x000D0000 - Accepted EULA version
-    res = CreateConfigInfoBlk(EULAVersionBlockID, 0x4, 0xE, zero_buffer);
+    res = CreateConfigInfoBlk(EULAVersionBlockID, 0x4, ConfigPermission::Public, zero_buffer);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(ConsoleModelBlockID, sizeof(CONSOLE_MODEL), 0xC, &CONSOLE_MODEL);
+    res = CreateConfigInfoBlk(ConsoleModelBlockID, sizeof(CONSOLE_MODEL), ConfigPermission::Private, &CONSOLE_MODEL);
     if (!res.IsSuccess()) return res;
 
     // 0x00170000 - Unknown
-    res = CreateConfigInfoBlk(0x00170000, 0x4, 0xE, zero_buffer);
+    res = CreateConfigInfoBlk(0x00170000, 0x4, ConfigPermission::Public, zero_buffer);
     if (!res.IsSuccess()) return res;
 
     // Save the buffer to the file
@@ -498,12 +504,12 @@ void SetUsername(std::u16string name) {
     ASSERT(name.size() <= 10);
     UsernameBlock block{};
     name.copy(block.username, name.size());
-    SetConfigInfoBlock(UsernameBlockID, sizeof(block), 4, &block);
+    SetConfigInfoBlock(UsernameBlockID, sizeof(block), true, &block);
 }
 
 std::u16string GetUsername() {
     UsernameBlock block;
-    GetConfigInfoBlock(UsernameBlockID, sizeof(block), 8, &block);
+    GetConfigInfoBlock(UsernameBlockID, sizeof(block), true, &block);
 
     // the username string in the block isn't null-terminated,
     // so copy it to a buffer to add trailing null char.
@@ -514,34 +520,34 @@ std::u16string GetUsername() {
 
 void SetBirthday(u8 month, u8 day) {
     BirthdayBlock block = { month, day };
-    SetConfigInfoBlock(BirthdayBlockID, sizeof(block), 4, &block);
+    SetConfigInfoBlock(BirthdayBlockID, sizeof(block), true, &block);
 }
 
 std::tuple<u8, u8> GetBirthday() {
     BirthdayBlock block;
-    GetConfigInfoBlock(BirthdayBlockID, sizeof(block), 8, &block);
+    GetConfigInfoBlock(BirthdayBlockID, sizeof(block), true, &block);
     return std::make_tuple(block.month, block.day);
 }
 
 void SetSystemLanguage(SystemLanguage language) {
     u8 block = language;
-    SetConfigInfoBlock(LanguageBlockID, sizeof(block), 4, &block);
+    SetConfigInfoBlock(LanguageBlockID, sizeof(block), true, &block);
 }
 
 SystemLanguage GetSystemLanguage() {
     u8 block;
-    GetConfigInfoBlock(LanguageBlockID, sizeof(block), 8, &block);
+    GetConfigInfoBlock(LanguageBlockID, sizeof(block), true, &block);
     return static_cast<SystemLanguage>(block);
 }
 
 void SetSoundOutputMode(SoundOutputMode mode) {
     u8 block = mode;
-    SetConfigInfoBlock(SoundOutputModeBlockID, sizeof(block), 4, &block);
+    SetConfigInfoBlock(SoundOutputModeBlockID, sizeof(block), true, &block);
 }
 
 SoundOutputMode GetSoundOutputMode() {
     u8 block;
-    GetConfigInfoBlock(SoundOutputModeBlockID, sizeof(block), 8, &block);
+    GetConfigInfoBlock(SoundOutputModeBlockID, sizeof(block), true, &block);
     return static_cast<SoundOutputMode>(block);
 }
 

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -35,7 +35,8 @@ enum SystemLanguage {
     LANGUAGE_KO = 7,
     LANGUAGE_NL = 8,
     LANGUAGE_PT = 9,
-    LANGUAGE_RU = 10
+    LANGUAGE_RU = 10,
+    LANGUAGE_TW = 11
 };
 
 enum SoundOutputMode {

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -38,6 +38,12 @@ enum SystemLanguage {
     LANGUAGE_RU = 10
 };
 
+enum SoundOutputMode {
+    SOUND_MONO = 0,
+    SOUND_STEREO = 1,
+    SOUND_SURROUND = 2
+};
+
 /// Block header in the config savedata file
 struct SaveConfigBlockEntry {
     u32 block_id;       ///< The id of the current block

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -185,6 +185,22 @@ void GetConfigInfoBlk2(Service::Interface* self);
 void GetConfigInfoBlk8(Service::Interface* self);
 
 /**
+ * CFG::SetConfigInfoBlk4 service function
+ *  Inputs:
+ *      0 : 0x04020082 / 0x08020082
+ *      1 : Block ID
+ *      2 : Size
+ *      3 : Descriptor for the output buffer
+ *      4 : Output buffer pointer
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ *  Note:
+ *      The parameters order is different from GetConfigInfoBlk2/8's,
+ *      where Block ID and Size are switched.
+ */
+void SetConfigInfoBlk4(Service::Interface* self);
+
+/**
  * CFG::UpdateConfigNANDSavegame service function
  *  Inputs:
  *      0 : 0x04030000 / 0x08030000
@@ -212,7 +228,19 @@ void FormatConfig(Service::Interface* self);
  * @param output A pointer where we will write the read data
  * @returns ResultCode indicating the result of the operation, 0 on success
  */
-ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, u8* output);
+ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, void* output);
+
+/**
+ * Reads data from input and writes to a block with the specified id and flag
+ * in the Config savegame buffer.
+ * The input size must match exactly the size of the target block
+ * @param block_id The id of the block we want to write
+ * @param size The size of the block we want to write
+ * @param flag The target block must have this flag set
+ * @param input A pointer where we will read data and write to Config savegame buffer
+ * @returns ResultCode indicating the result of the operation, 0 on success
+ */
+ResultCode SetConfigInfoBlock(u32 block_id, u32 size, u32 flag, void* input);
 
 /**
  * Creates a block with the specified id and writes the input data to the cfg savegame buffer in memory.

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -271,11 +271,70 @@ ResultCode UpdateConfigNANDSavegame();
  */
 ResultCode FormatConfig();
 
+/**
+ * Open the config savegame file and load it to the memory buffer
+ * @returns ResultCode indicating the result of the operation, 0 on success
+ */
+ResultCode LoadConfigNANDSaveFile();
+
 /// Initialize the config service
 void Init();
 
 /// Shutdown the config service
 void Shutdown();
+
+// Utilities for frontend to set config data.
+// Note: before calling these functions, LoadConfigNANDSaveFile should be called,
+// and UpdateConfigNANDSavegame should be called after making changes to config data.
+
+/**
+ * Sets the username in config savegame.
+ * @param name the username to set. The maximum size is 10 in char16_t.
+ */
+void SetUsername(std::u16string name);
+
+/**
+ * Gets the username from config savegame.
+ * @returns the username
+ */
+std::u16string GetUsername();
+
+/**
+ * Sets the profile birthday in config savegame.
+ * @param month the month of birthday.
+ * @param day the day of the birthday.
+ */
+void SetBirthday(u8 month, u8 day);
+
+/**
+ * Gets the profile birthday from the config savegame.
+ * @returns a tuple of (month, day) of birthday
+ */
+std::tuple<u8, u8> GetBirthday();
+
+/**
+ * Sets the system language in config savegame.
+ * @param language the system language to set.
+ */
+void SetSystemLanguage(SystemLanguage language);
+
+/**
+ * Gets the system language from config savegame.
+ * @returns the system language
+ */
+SystemLanguage GetSystemLanguage();
+
+/**
+ * Sets the sound output mode in config savegame.
+ * @param mode the sound output mode to set
+ */
+void SetSoundOutputMode(SoundOutputMode mode);
+
+/**
+ * Gets the sound output mode from config savegame.
+ * @returns the sound output mode
+ */
+SoundOutputMode GetSoundOutputMode();
 
 } // namespace CFG
 } // namespace Service

--- a/src/core/hle/service/cfg/cfg_i.cpp
+++ b/src/core/hle/service/cfg/cfg_i.cpp
@@ -22,7 +22,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x000A0040, GetCountryCodeID,                     "GetCountryCodeID"},
     // cfg:i
     {0x04010082, GetConfigInfoBlk8,                    "GetConfigInfoBlk8"},
-    {0x04020082, nullptr,                              "SetConfigInfoBlk4"},
+    {0x04020082, SetConfigInfoBlk4,                    "SetConfigInfoBlk4"},
     {0x04030000, UpdateConfigNANDSavegame,             "UpdateConfigNANDSavegame"},
     {0x04040042, nullptr,                              "GetLocalFriendCodeSeedData"},
     {0x04050000, nullptr,                              "GetLocalFriendCodeSeed"},
@@ -31,7 +31,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x04080042, nullptr,                              "SecureInfoGetSerialNo"},
     {0x04090000, nullptr,                              "UpdateConfigBlk00040003"},
     {0x08010082, GetConfigInfoBlk8,                    "GetConfigInfoBlk8"},
-    {0x08020082, nullptr,                              "SetConfigInfoBlk4"},
+    {0x08020082, SetConfigInfoBlk4,                    "SetConfigInfoBlk4"},
     {0x08030000, UpdateConfigNANDSavegame,             "UpdateConfigNANDSavegame"},
     {0x080400C2, nullptr,                              "CreateConfigInfoBlk"},
     {0x08050000, nullptr,                              "DeleteConfigNANDSavefile"},

--- a/src/core/hle/service/cfg/cfg_i.cpp
+++ b/src/core/hle/service/cfg/cfg_i.cpp
@@ -10,7 +10,7 @@ namespace CFG {
 
 const Interface::FunctionInfo FunctionTable[] = {
     // cfg common
-    {0x00010082, GetConfigInfoBlk2,                    "GetConfigInfoBlk2"},
+    {0x00010082, GetConfigInfoBlkUser,                 "GetConfigInfoBlkUser"},
     {0x00020000, SecureInfoGetRegion,                  "SecureInfoGetRegion"},
     {0x00030040, GenHashConsoleUnique,                 "GenHashConsoleUnique"},
     {0x00040000, GetRegionCanadaUSA,                   "GetRegionCanadaUSA"},
@@ -21,8 +21,8 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00090040, GetCountryCodeString,                 "GetCountryCodeString"},
     {0x000A0040, GetCountryCodeID,                     "GetCountryCodeID"},
     // cfg:i
-    {0x04010082, GetConfigInfoBlk8,                    "GetConfigInfoBlk8"},
-    {0x04020082, SetConfigInfoBlk4,                    "SetConfigInfoBlk4"},
+    {0x04010082, GetConfigInfoBlkSystem,               "GetConfigInfoBlk8"},
+    {0x04020082, SetConfigInfoBlkSystem,               "SetConfigInfoBlk4"},
     {0x04030000, UpdateConfigNANDSavegame,             "UpdateConfigNANDSavegame"},
     {0x04040042, nullptr,                              "GetLocalFriendCodeSeedData"},
     {0x04050000, nullptr,                              "GetLocalFriendCodeSeed"},
@@ -30,8 +30,8 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x04070000, nullptr,                              "SecureInfoGetByte101"},
     {0x04080042, nullptr,                              "SecureInfoGetSerialNo"},
     {0x04090000, nullptr,                              "UpdateConfigBlk00040003"},
-    {0x08010082, GetConfigInfoBlk8,                    "GetConfigInfoBlk8"},
-    {0x08020082, SetConfigInfoBlk4,                    "SetConfigInfoBlk4"},
+    {0x08010082, GetConfigInfoBlkSystem,               "GetConfigInfoBlkSystem"},
+    {0x08020082, SetConfigInfoBlkSystem,               "SetConfigInfoBlkSystem"},
     {0x08030000, UpdateConfigNANDSavegame,             "UpdateConfigNANDSavegame"},
     {0x080400C2, nullptr,                              "CreateConfigInfoBlk"},
     {0x08050000, nullptr,                              "DeleteConfigNANDSavefile"},

--- a/src/core/hle/service/cfg/cfg_s.cpp
+++ b/src/core/hle/service/cfg/cfg_s.cpp
@@ -22,7 +22,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x000A0040, GetCountryCodeID,                     "GetCountryCodeID"},
     // cfg:s
     {0x04010082, GetConfigInfoBlk8,                    "GetConfigInfoBlk8"},
-    {0x04020082, nullptr,                              "SetConfigInfoBlk4"},
+    {0x04020082, SetConfigInfoBlk4,                    "SetConfigInfoBlk4"},
     {0x04030000, UpdateConfigNANDSavegame,             "UpdateConfigNANDSavegame"},
     {0x04040042, nullptr,                              "GetLocalFriendCodeSeedData"},
     {0x04050000, nullptr,                              "GetLocalFriendCodeSeed"},

--- a/src/core/hle/service/cfg/cfg_s.cpp
+++ b/src/core/hle/service/cfg/cfg_s.cpp
@@ -10,7 +10,7 @@ namespace CFG {
 
 const Interface::FunctionInfo FunctionTable[] = {
     // cfg common
-    {0x00010082, GetConfigInfoBlk2,                    "GetConfigInfoBlk2"},
+    {0x00010082, GetConfigInfoBlkUser,                 "GetConfigInfoBlkUser"},
     {0x00020000, SecureInfoGetRegion,                  "SecureInfoGetRegion"},
     {0x00030040, GenHashConsoleUnique,                 "GenHashConsoleUnique"},
     {0x00040000, GetRegionCanadaUSA,                   "GetRegionCanadaUSA"},
@@ -21,8 +21,8 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00090040, GetCountryCodeString,                 "GetCountryCodeString"},
     {0x000A0040, GetCountryCodeID,                     "GetCountryCodeID"},
     // cfg:s
-    {0x04010082, GetConfigInfoBlk8,                    "GetConfigInfoBlk8"},
-    {0x04020082, SetConfigInfoBlk4,                    "SetConfigInfoBlk4"},
+    {0x04010082, GetConfigInfoBlkSystem,               "GetConfigInfoBlkSystem"},
+    {0x04020082, SetConfigInfoBlkSystem,               "SetConfigInfoBlkSystem"},
     {0x04030000, UpdateConfigNANDSavegame,             "UpdateConfigNANDSavegame"},
     {0x04040042, nullptr,                              "GetLocalFriendCodeSeedData"},
     {0x04050000, nullptr,                              "GetLocalFriendCodeSeed"},

--- a/src/core/hle/service/cfg/cfg_u.cpp
+++ b/src/core/hle/service/cfg/cfg_u.cpp
@@ -10,7 +10,7 @@ namespace CFG {
 
 const Interface::FunctionInfo FunctionTable[] = {
     // cfg common
-    {0x00010082, GetConfigInfoBlk2,     "GetConfigInfoBlk2"},
+    {0x00010082, GetConfigInfoBlkUser,  "GetConfigInfoBlkUser"},
     {0x00020000, SecureInfoGetRegion,   "SecureInfoGetRegion"},
     {0x00030040, GenHashConsoleUnique,  "GenHashConsoleUnique"},
     {0x00040000, GetRegionCanadaUSA,    "GetRegionCanadaUSA"},

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -255,7 +255,7 @@ using FileSys::ArchiveFactory;
 
 /**
  * Map of registered archives, identified by id code. Once an archive is registered here, it is
- * never removed until the FS service is shut down.
+ * never removed until UnregisterArchiveTypes is calld.
  */
 static boost::container::flat_map<ArchiveIdCode, std::unique_ptr<ArchiveFactory>> id_code_map;
 
@@ -516,12 +516,7 @@ ResultCode CreateSystemSaveData(u32 high, u32 low) {
     return RESULT_SUCCESS;
 }
 
-/// Initialize archives
-void ArchiveInit() {
-    next_handle = 1;
-
-    AddService(new FS::Interface);
-
+void RegisterArchiveTypes() {
     // TODO(Subv): Add the other archive types (see here for the known types:
     // http://3dbrew.org/wiki/FS:OpenArchive#Archive_idcodes).
 
@@ -558,10 +553,23 @@ void ArchiveInit() {
     RegisterArchiveType(std::move(systemsavedata_factory), ArchiveIdCode::SystemSaveData);
 }
 
+void UnregisterArchiveTypes() {
+    id_code_map.clear();
+}
+
+/// Initialize archives
+void ArchiveInit() {
+    next_handle = 1;
+
+    AddService(new FS::Interface);
+
+    RegisterArchiveTypes();
+}
+
 /// Shutdown archives
 void ArchiveShutdown() {
     handle_map.clear();
-    id_code_map.clear();
+    UnregisterArchiveTypes();
 }
 
 } // namespace FS

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -235,5 +235,11 @@ void ArchiveInit();
 /// Shutdown archives
 void ArchiveShutdown();
 
+/// Register all archive types
+void RegisterArchiveTypes();
+
+/// Unregister all archive types
+void UnregisterArchiveTypes();
+
 } // namespace FS
 } // namespace Service


### PR DESCRIPTION
_DRAFT_

This PR should be reviewed commit per commit.
Here is explanation for each commit.

### Add missing enums
>Service::CFG: name sound output modes
>Service::CFG: add missing language

These are independent to the rest of commits. The enum members are used nowhere (even not in the following system settings configure tab, because it matches codes to combo box indexes directly). They are added there just for completeness.

Note that `SoundOutputMode` happens to be the same as [`DSP::HLE::DspConfiguration::OutputFormat`](https://github.com/citra-emu/citra/blob/master/src/audio_core/hle/dsp.h#L355-359). I still defined a separate enum, for the following reason:
 - these two enum are too far away from each other in the code tree.
 - they are not related in program logic. It is the game that relates them.

### Add `SetConfigInfoBlk4` service function
>Service::CFG: add SetConfigInfoBlk4

Added the service function and refactored with `GetConfigInfoBlock`. Also added/fixed the error code for them. The error code is [hwtested](https://github.com/wwylele/ctrhwtest/tree/master/CFG_service_test)

`SetConfigInfoBlk4` can be tested by running 3DS System Settings app. (you can dump it from your 3DS NAND) However, when the app runs in Citra, it thinks Citra needs an initial system setup, then ask user to move the 3d slider (which is not implemented yet). There are ~~three~~ two ways to bypass:
 - ~~stub a value for 3d slider~~ (I failed)
 - dump a config savegame from real 3DS to citra
 - add the following code to to `cfg.cpp: FormatConfig()`, and remove the config savegame to let citra create a new one.
```c++ 
// 0x00110000 - System setup required?
u32 data = 0x00010001;
res = CreateConfigInfoBlk(0x00110000, 0x4, 0xE /*ConfigPermission::Public*/, &data);
if (!res.IsSuccess()) return res;
```

In System Settings, you can edit the username, birthday, language, etc (though the username can only be "Citra" due to stubbed software keyboard). They will be saved after changing.

### Add "system" tab to Qt's configure dialog
>Service::CFG: move known block ID to an enum
>Service::CFG/FS: add and refactor out utilities for front-end
>Qt: add system settings config tab

Allows user to change username, birthday, system language and sound output mode from front-end (i.e. edit these information in config block). System language selector is originally worked by @uberhalit  (_TODO: PR number here_).

The profile country / location information is also editable in theory, but they are more complicated and not well-REed, so I'd like to leave it to the next PR.

To prevent data race, the tab is disabled when game is running. Editing system settings during games makes no sense because this cannot be done on real 3DS, and won't benefit anything while game can be even not aware of user's changes.

### [RFC] Name config block permissions
>Service::CFG: name permissions

This is just my theory. If it is not good, I will remove this commit.

The theory is that the "flags" for each config block are actually access control / permissions. This is based on:
 - there is already a comment about this.
 - `GetConfigInfoBlk2` is accessible via all port, but `GetConfigInfoBlk8` and `SetConfigInfoBlk4` are only accessible via system port (`cfg:s`/`cfg:i`).
 - Each of these functions will check the corresponding flag. If the flag is not set, the function will return a `NotAuthorized` error code.
 - I checked my config savegame dumped from 3DS. All blocks have flag 4 and 8 set (that is, system can access all blocks), but only some of them, which contains public data for all games, have flag 2 set.

So it is not hard to conclude that flag 2 / 4 / 8  stand for "user (game) readable" / "system writeable" / "system read able". I also guess that flag 1 is for "user writeable" just for completeness, though this flag is never presented in any block or service function. Therefore, I named this permissions in the code so that we can get rid of those magic 2 / 4 / 8 .

--------------

_TODO_
- [x] hwtesting the behavior of `setConfigInfoBlk4`
- [x] clean up ui file
- [x] finish PR description
- [x] add sound settings
- [x] review