### PR TITLE
Emulate motion sensor in frontend

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRCS
             memory_util.cpp
             microprofile.cpp
             misc.cpp
+            motion_emu.cpp
             profiler.cpp
             scm_rev.cpp
             string_util.cpp
@@ -46,6 +47,7 @@ set(HEADERS
             memory_util.h
             microprofile.h
             microprofileui.h
+            motion_emu.h
             platform.h
             profiler_reporting.h
             scm_rev.h

--- a/src/common/emu_window.cpp
+++ b/src/common/emu_window.cpp
@@ -7,6 +7,7 @@
 
 #include "common/assert.h"
 #include "common/key_map.h"
+#include "common/profiler_reporting.h"
 
 #include "emu_window.h"
 #include "video_core/video_core.h"
@@ -89,6 +90,25 @@ void EmuWindow::TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y) {
         std::tie(framebuffer_x, framebuffer_y) = ClipToTouchScreen(framebuffer_x, framebuffer_y);
 
     TouchPressed(framebuffer_x, framebuffer_y);
+}
+
+void EmuWindow::AccelerometerChanged(float x, float y, float z) {
+    constexpr float coef = 512;
+
+    // TODO(wwylele): do a time stretch as it in GyroscopeChanged
+    // The time stretch formula should be like
+    // stretched_vector = (raw_vector - gravity) * stretch_ratio + gravity
+    accel_x = x * coef;
+    accel_y = y * coef;
+    accel_z = z * coef;
+}
+
+void EmuWindow::GyroscopeChanged(float x, float y, float z) {
+    float coef = GetGyroscopeRawToDpsCoefficient();
+    float stretch = 60 / Common::Profiling::GetTimingResultsAggregator()->GetAggregatedResults().fps;
+    gyro_x = x * coef * stretch;
+    gyro_y = y * coef * stretch;
+    gyro_z = z * coef * stretch;
 }
 
 EmuWindow::FramebufferLayout EmuWindow::FramebufferLayout::DefaultScreenLayout(unsigned width, unsigned height) {

--- a/src/common/emu_window.h
+++ b/src/common/emu_window.h
@@ -112,6 +112,27 @@ public:
     void TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y);
 
     /**
+     * Signal accelerometer state has changed.
+     * @param x X-axis accelerometer value
+     * @param y Y-axis accelerometer value
+     * @param z Z-axis accelerometer value
+     * @note all values are in unit of g (gravitational acceleration).
+     *    e.g. x = 1.0 means 9.8m/s^2 in x direction.
+     *    see GetAccelerometerState for axis explanation.
+     */
+    void AccelerometerChanged(float x, float y, float z);
+
+    /**
+     * Signal gyroscope state has changed.
+     * @param x X-axis accelerometer value
+     * @param y Y-axis accelerometer value
+     * @param z Z-axis accelerometer value
+     * @note all values are in deg/sec.
+     *    see GetGyroscopeState for axis explanation.
+     */
+    void GyroscopeChanged(float x, float y, float z);
+
+    /**
      * Gets the current pad state (which buttons are pressed).
      * @note This should be called by the core emu thread to get a state set by the window thread.
      * @note This doesn't include analog input like circle pad direction
@@ -153,12 +174,11 @@ public:
      *   1 unit of return value = 1/512 g (measured by hw test),
      *   where g is the gravitational acceleration (9.8 m/sec2).
      * @note This should be called by the core emu thread to get a state set by the window thread.
-     * @todo Implement accelerometer input in front-end.
+     * @todo Fix this function to be thread-safe.
      * @return std::tuple of (x, y, z)
      */
-    std::tuple<s16, s16, s16> GetAccelerometerState() const {
-        // stubbed
-        return std::make_tuple(0, -512, 0);
+    std::tuple<s16, s16, s16> GetAccelerometerState() {
+        return std::make_tuple(accel_x, accel_y, accel_z);
     }
 
     /**
@@ -172,12 +192,11 @@ public:
      *   1 unit of return value = (1/coef) deg/sec,
      *   where coef is the return value of GetGyroscopeRawToDpsCoefficient().
      * @note This should be called by the core emu thread to get a state set by the window thread.
-     * @todo Implement gyroscope input in front-end.
+     * @todo Fix this function to be thread-safe.
      * @return std::tuple of (x, y, z)
      */
-    std::tuple<s16, s16, s16> GetGyroscopeState() const {
-        // stubbed
-        return std::make_tuple(0, 0, 0);
+    std::tuple<s16, s16, s16> GetGyroscopeState() {
+        return std::make_tuple(gyro_x, gyro_y, gyro_z);
     }
 
     /**
@@ -226,6 +245,12 @@ protected:
         circle_pad_x = 0;
         circle_pad_y = 0;
         touch_pressed = false;
+        accel_x = 0;
+        accel_y = -512;
+        accel_z = 0;
+        gyro_x = 0;
+        gyro_y = 0;
+        gyro_z = 0;
     }
     virtual ~EmuWindow() {}
 
@@ -287,6 +312,14 @@ private:
 
     s16 circle_pad_x; ///< Circle pad X-position in native 3DS pixel coordinates (-156 - 156)
     s16 circle_pad_y; ///< Circle pad Y-position in native 3DS pixel coordinates (-156 - 156)
+
+    s16 accel_x; ///< Accelerometer X-axis value in native 3DS unit
+    s16 accel_y; ///< Accelerometer Y-axis value in native 3DS unit
+    s16 accel_z; ///< Accelerometer Z-axis value in native 3DS unit
+
+    s16 gyro_x; ///< Gyroscope X-axis value in native 3DS unit
+    s16 gyro_y; ///< Gyroscope Y-axis value in native 3DS unit
+    s16 gyro_z; ///< Gyroscope Z-axis value in native 3DS unit
 
    /**
     * Clip the provided coordinates to be inside the touchscreen area.

--- a/src/common/motion_emu.cpp
+++ b/src/common/motion_emu.cpp
@@ -1,0 +1,135 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/emu_window.h"
+#include "common/math_util.h"
+#include "common/motion_emu.h"
+#include "common/thread.h"
+#include "common/vector_math.h"
+
+namespace MotionEmu {
+
+struct Quaternion {
+    Math::Vec3<float> xyz;
+    float w;
+
+    Quaternion Inverse() {
+        return Quaternion { -xyz, w };
+    }
+
+    Quaternion operator- (const Quaternion& a) {
+        return Quaternion { xyz - a.xyz, w - a.w };
+    }
+};
+
+inline Quaternion Product(const Quaternion& a, const Quaternion& b) {
+    return Quaternion {
+        a.xyz * b.w + b.xyz * a.w + Cross(a.xyz, b.xyz),
+        a.w * b.w + Dot(a.xyz, b.xyz)
+    };
+}
+
+inline Quaternion MakeQuaternion(const Math::Vec3<float>& axis, float angle) {
+    return Quaternion {
+        axis * std::sin(angle / 2),
+        std::cos(angle / 2)
+    };
+}
+
+inline Math::Vec3<float> QuaternionRotate(const Quaternion& q, const Math::Vec3<float>& v) {
+    return v + 2 * Cross(q.xyz, Cross(q.xyz, v) + v * q.w);
+}
+
+static std::unique_ptr<std::thread> motion_emu_thread;
+static Common::Event shutdown_event;
+
+static constexpr int update_millisecond = 100;
+static constexpr auto update_duration =
+    std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::milliseconds(update_millisecond));
+static constexpr float PI = 3.14159265f;
+
+static Math::Vec2<int> mouse_origin;
+
+static std::mutex tilt_mutex;
+static Math::Vec2<float> tilt_direction;
+static float tilt_angle;
+
+static bool is_tilting;
+
+static void MotionEmuThread(EmuWindow& emu_window) {
+    auto update_time = std::chrono::steady_clock::now();
+    Quaternion q = MakeQuaternion(Math::Vec3<float>(), 0) , old_q;
+
+    while (!shutdown_event.WaitUntil(update_time)) {
+        update_time += update_duration;
+        old_q = q;
+
+        {
+            std::lock_guard<std::mutex> guard(tilt_mutex);
+
+            // Find the quaternion describing current 3DS tilting
+            q = MakeQuaternion(Math::MakeVec(-tilt_direction.y, 0.0f, tilt_direction.x), tilt_angle);
+        }
+
+        auto inv_q = q.Inverse();
+
+        // Set the gravity vector in world space
+        auto gravity = Math::MakeVec(0.0f, -1.0f, 0.0f);
+
+        // Find the angular rate vector in world space
+        auto angular_rate = Product(q - old_q, inv_q).xyz * 2;
+        angular_rate *= 1000 / update_millisecond / PI * 180;
+
+        // Transform the two vectors from world space to 3DS space
+        gravity = QuaternionRotate(inv_q, gravity);
+        angular_rate = QuaternionRotate(inv_q, angular_rate);
+
+        // Update the sensor state
+        emu_window.AccelerometerChanged(gravity.x, gravity.y, gravity.z);
+        emu_window.GyroscopeChanged(angular_rate.x, angular_rate.y, angular_rate.z);
+    }
+}
+
+void Init(EmuWindow& emu_window) {
+    Shutdown();
+    tilt_angle = 0;
+    is_tilting = false;
+    motion_emu_thread = std::make_unique<std::thread>(MotionEmuThread, std::ref(emu_window));
+}
+
+void Shutdown() {
+    if (motion_emu_thread) {
+        shutdown_event.Set();
+        motion_emu_thread->join();
+        motion_emu_thread = nullptr;
+    }
+}
+
+void BeginTilt(int x, int y) {
+    mouse_origin = Math::MakeVec(x, y);
+    is_tilting = true;
+}
+
+void Tilt(int x, int y) {
+    constexpr float SENSITIVITY = 0.01f;
+    auto mouse_move = Math::MakeVec(x, y) - mouse_origin;
+    if (is_tilting) {
+        std::lock_guard<std::mutex> guard(tilt_mutex);
+        if (mouse_move.x == 0 && mouse_move.y == 0) {
+            tilt_angle = 0;
+        } else {
+            tilt_direction = mouse_move.Cast<float>();
+            tilt_angle = MathUtil::Clamp(tilt_direction.Normalize() * SENSITIVITY, 0.0f, PI * 0.5f);
+        }
+    }
+
+}
+
+void EndTilt() {
+    std::lock_guard<std::mutex> guard(tilt_mutex);
+    tilt_angle = 0;
+    is_tilting = false;
+}
+
+}

--- a/src/common/motion_emu.h
+++ b/src/common/motion_emu.h
@@ -1,0 +1,41 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+class EmuWindow;
+
+namespace MotionEmu {
+
+/**
+ * Starts the motion emulation thread.
+ * @param emu_window the EmuWindow to signal sensor state change
+ */
+void Init(EmuWindow& emu_window);
+
+/**
+ * Stops the motion emulation thread.
+ */
+void Shutdown();
+
+/**
+ * Signals the user begins tilting (e.g. the right button was pressed).
+ * @param x the x-coordinate of the cursor
+ * @param y the y-coordinate of the cursor
+ */
+void BeginTilt(int x, int y);
+
+/**
+ * Signals the user tilts (e.g. mouse was moved over the emu window).
+ * @param x the x-coordinate of the cursor
+ * @param y the y-coordinate of the cursor
+ */
+void Tilt(int x, int y);
+
+/**
+ * Signals the user stops tilting (e.g. the right button was released).
+ */
+void EndTilt();
+
+}

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <thread>
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
 
@@ -53,6 +54,14 @@ public:
         std::unique_lock<std::mutex> lk(mutex);
         condvar.wait(lk, [&]{ return is_set; });
         is_set = false;
+    }
+
+    template <class Clock, class Duration>
+    bool WaitUntil(const std::chrono::time_point<Clock, Duration>& time) {
+        std::unique_lock<std::mutex> lk(mutex);
+        if (!condvar.wait_until(lk, time, [&]{ return is_set; })) return false;
+        is_set = false;
+        return true;
     }
 
     void Reset() {

--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -173,6 +173,18 @@ Vec2<T> operator * (const V& f, const Vec2<T>& vec)
 
 typedef Vec2<float> Vec2f;
 
+template<>
+inline float Vec2<float>::Length() const {
+    return std::sqrt(x * x + y * y);
+}
+
+template<>
+inline float Vec2<float>::Normalize() {
+    float length = Length();
+    *this /= length;
+    return length;
+}
+
 template<typename T>
 class Vec3
 {
@@ -341,6 +353,12 @@ inline Vec3<float> Vec3<float>::Normalized() const {
     return *this / Length();
 }
 
+template<>
+inline float Vec3<float>::Normalize() {
+    float length = Length();
+    *this /= length;
+    return length;
+}
 
 typedef Vec3<float> Vec3f;
 


### PR DESCRIPTION
_DRAFT_

As a continuation of _TODO_.

This is a relatively old branch of mine, which still contains problems. But I want to PR this before it becomes completely stale, and discuss some questions below.

Usage: move mouse in the emulation window while holding the right button.

It emulates the accelerometer and gyroscope in a very limited range: it can only tilt in the direction of mouse movement, no rotate about the vertical (y) axis, and no linear acceleration. I also limited the tilt angle to be less than 90 degree, because I received reports saying that freeing the range to 180 degree will confuse the user (I also felt that when testing).

I don't have many games using motion sensor, so not sure if there is other common motion should be emulated.

In `EmuWindow`, gyroscope data are "stretched" according to current running speed, because in the view of slow-paced game, the motion of the "3DS" is faster. A similar time stretching should be also applied to the accelerometer, but the formula is much more complicated, and it is meaningless at current stage because only gravity are emulated (which won't be stretched) without linear acceleration(which should be stretched).

__QUESTIONS__
 - Is PI defined somewhere in our code base? If not, where should I put it?
 - how to measure the running speed? This is needed for doing time stretching. Currently I use the profiler to get the FPS as the speed. Is it good? What's the better way?
 - the [updating time interval](https://github.com/wwylele/citra/pull/2/files#diff-58315aeb8808393b7ed57620acb3b8bfR47) and the [sensitivity coefficient](https://github.com/wwylele/citra/pull/2/files#diff-58315aeb8808393b7ed57620acb3b8bfR47) are chosen arbitrarily. Is it good? 

_TODO_
 - [x] Document
 - [x] Time stretch
 - [x] Review
