### PR TITLE
FS: implement archives for other game save data

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SRCS
             file_sys/archive_savedata.cpp
             file_sys/archive_sdmc.cpp
             file_sys/archive_sdmcwriteonly.cpp
+            file_sys/archive_source_sd_savedata.cpp
             file_sys/archive_systemsavedata.cpp
             file_sys/disk_archive.cpp
             file_sys/ivfc_archive.cpp
@@ -167,6 +168,7 @@ set(HEADERS
             file_sys/archive_savedata.h
             file_sys/archive_sdmc.h
             file_sys/archive_sdmcwriteonly.h
+            file_sys/archive_source_sd_savedata.h
             file_sys/archive_systemsavedata.h
             file_sys/directory_backend.h
             file_sys/disk_archive.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SRCS
             file_sys/archive_backend.cpp
             file_sys/archive_extsavedata.cpp
             file_sys/archive_ncch.cpp
+            file_sys/archive_other_savedata.cpp
             file_sys/archive_romfs.cpp
             file_sys/archive_savedata.cpp
             file_sys/archive_sdmc.cpp
@@ -164,6 +165,7 @@ set(HEADERS
             file_sys/archive_backend.h
             file_sys/archive_extsavedata.h
             file_sys/archive_ncch.h
+            file_sys/archive_other_savedata.h
             file_sys/archive_romfs.h
             file_sys/archive_savedata.h
             file_sys/archive_sdmc.h

--- a/src/core/file_sys/archive_other_savedata.cpp
+++ b/src/core/file_sys/archive_other_savedata.cpp
@@ -1,0 +1,139 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <tuple>
+#include "core/file_sys/archive_other_savedata.h"
+#include "core/file_sys/errors.h"
+#include "core/hle/kernel/process.h"
+#include "core/hle/service/fs/archive.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// FileSys namespace
+
+namespace FileSys {
+
+// TODO(wwylele): The storage info in exheader should be checked before accessing these archives
+
+using Service::FS::MediaType;
+
+template <typename T>
+static ResultVal<std::tuple<MediaType, u64>> ParsePath(const Path& path, T program_id_reader) {
+    if (path.GetType() != Binary) {
+        LOG_ERROR(Service_FS, "Wrong path type %d", static_cast<int>(path.GetType()));
+        return ERROR_INVALID_PATH;
+    }
+
+    std::vector<u8> vec_data = path.AsBinary();
+
+    if (vec_data.size() != 12) {
+        LOG_ERROR(Service_FS, "Wrong path length %zu", vec_data.size());
+        return ERROR_INVALID_PATH;
+    }
+
+    const u32* data = reinterpret_cast<const u32*>(vec_data.data());
+    auto media_type = static_cast<MediaType>(data[0]);
+
+    if (media_type != MediaType::SDMC && media_type != MediaType::GameCard) {
+        LOG_ERROR(Service_FS, "Unsupported media type %u", static_cast<u32>(media_type));
+        return ERROR_UNSUPPORTED_OPEN_FLAGS; // Note: this is strange, but it is got from 3DS
+    }
+
+    return MakeResult<std::tuple<MediaType, u64>>(media_type, program_id_reader(data));
+}
+
+static ResultVal<std::tuple<MediaType, u64>> ParsePathPermitted(const Path& path) {
+    return ParsePath(path,
+                     [](const u32* data) -> u64 { return (data[1] << 8) | 0x0004000000000000ULL; });
+}
+
+static ResultVal<std::tuple<MediaType, u64>> ParsePathGeneral(const Path& path) {
+    return ParsePath(
+        path, [](const u32* data) -> u64 { return data[1] | (static_cast<u64>(data[2]) << 32); });
+}
+
+ArchiveFactory_OtherSaveDataPermitted::ArchiveFactory_OtherSaveDataPermitted(
+    std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata)
+    : sd_savedata_source(sd_savedata) {}
+
+ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_OtherSaveDataPermitted::Open(
+    const Path& path) {
+    MediaType media_type;
+    u64 program_id;
+    CASCADE_RESULT(std::tie(media_type, program_id), ParsePathPermitted(path));
+
+    if (media_type == MediaType::GameCard) {
+        LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
+        return ERROR_GAMECARD_NOT_INSERTED;
+    }
+
+    return sd_savedata_source->Open(program_id);
+}
+
+ResultCode ArchiveFactory_OtherSaveDataPermitted::Format(
+    const Path& path, const FileSys::ArchiveFormatInfo& format_info) {
+    LOG_ERROR(Service_FS, "Attempted to format a OtherSaveDataPermitted archive.");
+    return ERROR_INVALID_PATH;
+}
+
+ResultVal<ArchiveFormatInfo> ArchiveFactory_OtherSaveDataPermitted::GetFormatInfo(
+    const Path& path) const {
+    MediaType media_type;
+    u64 program_id;
+    CASCADE_RESULT(std::tie(media_type, program_id), ParsePathPermitted(path));
+
+    if (media_type == MediaType::GameCard) {
+        LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
+        return ERROR_GAMECARD_NOT_INSERTED;
+    }
+
+    return sd_savedata_source->GetFormatInfo(program_id);
+}
+
+ArchiveFactory_OtherSaveDataGeneral::ArchiveFactory_OtherSaveDataGeneral(
+    std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata)
+    : sd_savedata_source(sd_savedata) {}
+
+ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_OtherSaveDataGeneral::Open(
+    const Path& path) {
+    MediaType media_type;
+    u64 program_id;
+    CASCADE_RESULT(std::tie(media_type, program_id), ParsePathGeneral(path));
+
+    if (media_type == MediaType::GameCard) {
+        LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
+        return ERROR_GAMECARD_NOT_INSERTED;
+    }
+
+    return sd_savedata_source->Open(program_id);
+}
+
+ResultCode ArchiveFactory_OtherSaveDataGeneral::Format(
+    const Path& path, const FileSys::ArchiveFormatInfo& format_info) {
+    MediaType media_type;
+    u64 program_id;
+    CASCADE_RESULT(std::tie(media_type, program_id), ParsePathGeneral(path));
+
+    if (media_type == MediaType::GameCard) {
+        LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
+        return ERROR_GAMECARD_NOT_INSERTED;
+    }
+
+    return sd_savedata_source->Format(program_id, format_info);
+}
+
+ResultVal<ArchiveFormatInfo> ArchiveFactory_OtherSaveDataGeneral::GetFormatInfo(
+    const Path& path) const {
+    MediaType media_type;
+    u64 program_id;
+    CASCADE_RESULT(std::tie(media_type, program_id), ParsePathGeneral(path));
+
+    if (media_type == MediaType::GameCard) {
+        LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
+        return ERROR_GAMECARD_NOT_INSERTED;
+    }
+
+    return sd_savedata_source->GetFormatInfo(program_id);
+}
+
+} // namespace FileSys

--- a/src/core/file_sys/archive_other_savedata.h
+++ b/src/core/file_sys/archive_other_savedata.h
@@ -1,0 +1,52 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/file_sys/archive_source_sd_savedata.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// FileSys namespace
+
+namespace FileSys {
+
+/// File system interface to the OtherSaveDataPermitted archive
+class ArchiveFactory_OtherSaveDataPermitted final : public ArchiveFactory {
+public:
+    ArchiveFactory_OtherSaveDataPermitted(
+        std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata_source);
+
+    std::string GetName() const override {
+        return "OtherSaveDataPermitted";
+    }
+
+    ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path) override;
+    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info) override;
+    ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path) const override;
+
+private:
+    std::string mount_point;
+    std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata_source;
+};
+
+/// File system interface to the OtherSaveDataGeneral archive
+class ArchiveFactory_OtherSaveDataGeneral final : public ArchiveFactory {
+public:
+    ArchiveFactory_OtherSaveDataGeneral(
+        std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata_source);
+
+    std::string GetName() const override {
+        return "OtherSaveDataGeneral";
+    }
+
+    ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path) override;
+    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info) override;
+    ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path) const override;
+
+private:
+    std::string mount_point;
+    std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata_source;
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/archive_savedata.cpp
+++ b/src/core/file_sys/archive_savedata.cpp
@@ -2,96 +2,29 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <algorithm>
-#include <memory>
-#include "common/common_types.h"
-#include "common/file_util.h"
-#include "common/logging/log.h"
-#include "common/string_util.h"
 #include "core/file_sys/archive_savedata.h"
-#include "core/file_sys/savedata_archive.h"
 #include "core/hle/kernel/process.h"
-#include "core/hle/service/fs/archive.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // FileSys namespace
 
 namespace FileSys {
 
-static std::string GetSaveDataContainerPath(const std::string& sdmc_directory) {
-    return Common::StringFromFormat("%sNintendo 3DS/%s/%s/title/", sdmc_directory.c_str(),
-                                    SYSTEM_ID.c_str(), SDCARD_ID.c_str());
-}
-
-static std::string GetSaveDataPath(const std::string& mount_location, u64 program_id) {
-    u32 high = (u32)(program_id >> 32);
-    u32 low = (u32)(program_id & 0xFFFFFFFF);
-    return Common::StringFromFormat("%s%08x/%08x/data/00000001/", mount_location.c_str(), high,
-                                    low);
-}
-
-static std::string GetSaveDataMetadataPath(const std::string& mount_location, u64 program_id) {
-    u32 high = (u32)(program_id >> 32);
-    u32 low = (u32)(program_id & 0xFFFFFFFF);
-    return Common::StringFromFormat("%s%08x/%08x/data/00000001.metadata", mount_location.c_str(),
-                                    high, low);
-}
-
-ArchiveFactory_SaveData::ArchiveFactory_SaveData(const std::string& sdmc_directory)
-    : mount_point(GetSaveDataContainerPath(sdmc_directory)) {
-    LOG_INFO(Service_FS, "Directory %s set as SaveData.", this->mount_point.c_str());
-}
+ArchiveFactory_SaveData::ArchiveFactory_SaveData(
+    std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata)
+    : sd_savedata_source(sd_savedata) {}
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SaveData::Open(const Path& path) {
-    std::string concrete_mount_point =
-        GetSaveDataPath(mount_point, Kernel::g_current_process->codeset->program_id);
-    if (!FileUtil::Exists(concrete_mount_point)) {
-        // When a SaveData archive is created for the first time, it is not yet formatted and the
-        // save file/directory structure expected by the game has not yet been initialized.
-        // Returning the NotFormatted error code will signal the game to provision the SaveData
-        // archive with the files and folders that it expects.
-        return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
-                          ErrorSummary::InvalidState, ErrorLevel::Status);
-    }
-
-    auto archive = std::make_unique<SaveDataArchive>(std::move(concrete_mount_point));
-    return MakeResult<std::unique_ptr<ArchiveBackend>>(std::move(archive));
+    return sd_savedata_source->Open(Kernel::g_current_process->codeset->program_id);
 }
 
 ResultCode ArchiveFactory_SaveData::Format(const Path& path,
                                            const FileSys::ArchiveFormatInfo& format_info) {
-    std::string concrete_mount_point =
-        GetSaveDataPath(mount_point, Kernel::g_current_process->codeset->program_id);
-    FileUtil::DeleteDirRecursively(concrete_mount_point);
-    FileUtil::CreateFullPath(concrete_mount_point);
-
-    // Write the format metadata
-    std::string metadata_path =
-        GetSaveDataMetadataPath(mount_point, Kernel::g_current_process->codeset->program_id);
-    FileUtil::IOFile file(metadata_path, "wb");
-
-    if (file.IsOpen()) {
-        file.WriteBytes(&format_info, sizeof(format_info));
-        return RESULT_SUCCESS;
-    }
-    return RESULT_SUCCESS;
+    return sd_savedata_source->Format(Kernel::g_current_process->codeset->program_id, format_info);
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveFactory_SaveData::GetFormatInfo(const Path& path) const {
-    std::string metadata_path =
-        GetSaveDataMetadataPath(mount_point, Kernel::g_current_process->codeset->program_id);
-    FileUtil::IOFile file(metadata_path, "rb");
-
-    if (!file.IsOpen()) {
-        LOG_ERROR(Service_FS, "Could not open metadata information for archive");
-        // TODO(Subv): Verify error code
-        return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
-                          ErrorSummary::InvalidState, ErrorLevel::Status);
-    }
-
-    ArchiveFormatInfo info = {};
-    file.ReadBytes(&info, sizeof(info));
-    return MakeResult<ArchiveFormatInfo>(info);
+    return sd_savedata_source->GetFormatInfo(Kernel::g_current_process->codeset->program_id);
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/archive_savedata.h
+++ b/src/core/file_sys/archive_savedata.h
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include "core/file_sys/archive_backend.h"
-#include "core/hle/result.h"
+#include "core/file_sys/archive_source_sd_savedata.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // FileSys namespace
@@ -17,7 +14,7 @@ namespace FileSys {
 /// File system interface to the SaveData archive
 class ArchiveFactory_SaveData final : public ArchiveFactory {
 public:
-    ArchiveFactory_SaveData(const std::string& mount_point);
+    ArchiveFactory_SaveData(std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata_source);
 
     std::string GetName() const override {
         return "SaveData";
@@ -30,6 +27,7 @@ public:
 
 private:
     std::string mount_point;
+    std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata_source;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/archive_source_sd_savedata.cpp
+++ b/src/core/file_sys/archive_source_sd_savedata.cpp
@@ -1,0 +1,89 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/file_util.h"
+#include "common/logging/log.h"
+#include "common/string_util.h"
+#include "core/file_sys/archive_source_sd_savedata.h"
+#include "core/file_sys/savedata_archive.h"
+#include "core/hle/service/fs/archive.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// FileSys namespace
+
+namespace FileSys {
+
+static std::string GetSaveDataContainerPath(const std::string& sdmc_directory) {
+    return Common::StringFromFormat("%sNintendo 3DS/%s/%s/title/", sdmc_directory.c_str(),
+                                    SYSTEM_ID.c_str(), SDCARD_ID.c_str());
+}
+
+static std::string GetSaveDataPath(const std::string& mount_location, u64 program_id) {
+    u32 high = (u32)(program_id >> 32);
+    u32 low = (u32)(program_id & 0xFFFFFFFF);
+    return Common::StringFromFormat("%s%08x/%08x/data/00000001/", mount_location.c_str(), high,
+                                    low);
+}
+
+static std::string GetSaveDataMetadataPath(const std::string& mount_location, u64 program_id) {
+    u32 high = (u32)(program_id >> 32);
+    u32 low = (u32)(program_id & 0xFFFFFFFF);
+    return Common::StringFromFormat("%s%08x/%08x/data/00000001.metadata", mount_location.c_str(),
+                                    high, low);
+}
+
+ArchiveSource_SDSaveData::ArchiveSource_SDSaveData(const std::string& sdmc_directory)
+    : mount_point(GetSaveDataContainerPath(sdmc_directory)) {
+    LOG_INFO(Service_FS, "Directory %s set as SaveData.", this->mount_point.c_str());
+}
+
+ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveSource_SDSaveData::Open(u64 program_id) {
+    std::string concrete_mount_point = GetSaveDataPath(mount_point, program_id);
+    if (!FileUtil::Exists(concrete_mount_point)) {
+        // When a SaveData archive is created for the first time, it is not yet formatted and the
+        // save file/directory structure expected by the game has not yet been initialized.
+        // Returning the NotFormatted error code will signal the game to provision the SaveData
+        // archive with the files and folders that it expects.
+        return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
+                          ErrorSummary::InvalidState, ErrorLevel::Status);
+    }
+
+    auto archive = std::make_unique<SaveDataArchive>(std::move(concrete_mount_point));
+    return MakeResult<std::unique_ptr<ArchiveBackend>>(std::move(archive));
+}
+
+ResultCode ArchiveSource_SDSaveData::Format(u64 program_id,
+                                            const FileSys::ArchiveFormatInfo& format_info) {
+    std::string concrete_mount_point = GetSaveDataPath(mount_point, program_id);
+    FileUtil::DeleteDirRecursively(concrete_mount_point);
+    FileUtil::CreateFullPath(concrete_mount_point);
+
+    // Write the format metadata
+    std::string metadata_path = GetSaveDataMetadataPath(mount_point, program_id);
+    FileUtil::IOFile file(metadata_path, "wb");
+
+    if (file.IsOpen()) {
+        file.WriteBytes(&format_info, sizeof(format_info));
+        return RESULT_SUCCESS;
+    }
+    return RESULT_SUCCESS;
+}
+
+ResultVal<ArchiveFormatInfo> ArchiveSource_SDSaveData::GetFormatInfo(u64 program_id) const {
+    std::string metadata_path = GetSaveDataMetadataPath(mount_point, program_id);
+    FileUtil::IOFile file(metadata_path, "rb");
+
+    if (!file.IsOpen()) {
+        LOG_ERROR(Service_FS, "Could not open metadata information for archive");
+        // TODO(Subv): Verify error code
+        return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
+                          ErrorSummary::InvalidState, ErrorLevel::Status);
+    }
+
+    ArchiveFormatInfo info = {};
+    file.ReadBytes(&info, sizeof(info));
+    return MakeResult<ArchiveFormatInfo>(info);
+}
+
+} // namespace FileSys

--- a/src/core/file_sys/archive_source_sd_savedata.h
+++ b/src/core/file_sys/archive_source_sd_savedata.h
@@ -1,0 +1,30 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include "core/file_sys/archive_backend.h"
+#include "core/hle/result.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// FileSys namespace
+
+namespace FileSys {
+
+/// A common source of SD save data archive
+class ArchiveSource_SDSaveData {
+public:
+    ArchiveSource_SDSaveData(const std::string& mount_point);
+
+    ResultVal<std::unique_ptr<ArchiveBackend>> Open(u64 program_id);
+    ResultCode Format(u64 program_id, const FileSys::ArchiveFormatInfo& format_info);
+    ResultVal<ArchiveFormatInfo> GetFormatInfo(u64 program_id) const;
+
+private:
+    std::string mount_point;
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -36,5 +36,8 @@ const ResultCode ERROR_ALREADY_EXISTS(ErrorDescription::FS_AlreadyExists, ErrorM
                                       ErrorSummary::NothingHappened, ErrorLevel::Status);
 const ResultCode ERROR_DIRECTORY_NOT_EMPTY(ErrorDescription::FS_DirectoryNotEmpty, ErrorModule::FS,
                                            ErrorSummary::Canceled, ErrorLevel::Status);
+const ResultCode ERROR_GAMECARD_NOT_INSERTED(ErrorDescription::FS_GameCardNotInserted,
+                                             ErrorModule::FS, ErrorSummary::NotFound,
+                                             ErrorLevel::Status);
 
 } // namespace FileSys

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -22,6 +22,7 @@ enum class ErrorDescription : u32 {
     FS_ArchiveNotMounted = 101,
     FS_FileNotFound = 112,
     FS_PathNotFound = 113,
+    FS_GameCardNotInserted = 141,
     FS_NotFound = 120,
     FS_FileAlreadyExists = 180,
     FS_DirectoryAlreadyExists = 185,

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -535,7 +535,8 @@ void RegisterArchiveTypes() {
                   sdmc_directory.c_str());
 
     // Create the SaveData archive
-    auto savedata_factory = std::make_unique<FileSys::ArchiveFactory_SaveData>(sdmc_directory);
+    auto sd_savedata_source = std::make_shared<FileSys::ArchiveSource_SDSaveData>(sdmc_directory);
+    auto savedata_factory = std::make_unique<FileSys::ArchiveFactory_SaveData>(sd_savedata_source);
     RegisterArchiveType(std::move(savedata_factory), ArchiveIdCode::SaveData);
 
     auto extsavedata_factory =

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -16,6 +16,7 @@
 #include "core/file_sys/archive_backend.h"
 #include "core/file_sys/archive_extsavedata.h"
 #include "core/file_sys/archive_ncch.h"
+#include "core/file_sys/archive_other_savedata.h"
 #include "core/file_sys/archive_savedata.h"
 #include "core/file_sys/archive_sdmc.h"
 #include "core/file_sys/archive_sdmcwriteonly.h"
@@ -538,6 +539,14 @@ void RegisterArchiveTypes() {
     auto sd_savedata_source = std::make_shared<FileSys::ArchiveSource_SDSaveData>(sdmc_directory);
     auto savedata_factory = std::make_unique<FileSys::ArchiveFactory_SaveData>(sd_savedata_source);
     RegisterArchiveType(std::move(savedata_factory), ArchiveIdCode::SaveData);
+    auto other_savedata_permitted_factory =
+        std::make_unique<FileSys::ArchiveFactory_OtherSaveDataPermitted>(sd_savedata_source);
+    RegisterArchiveType(std::move(other_savedata_permitted_factory),
+                        ArchiveIdCode::OtherSaveDataPermitted);
+    auto other_savedata_general_factory =
+        std::make_unique<FileSys::ArchiveFactory_OtherSaveDataGeneral>(sd_savedata_source);
+    RegisterArchiveType(std::move(other_savedata_general_factory),
+                        ArchiveIdCode::OtherSaveDataGeneral);
 
     auto extsavedata_factory =
         std::make_unique<FileSys::ArchiveFactory_ExtSaveData>(sdmc_directory, false);

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -34,6 +34,8 @@ enum class ArchiveIdCode : u32 {
     SDMC = 0x00000009,
     SDMCWriteOnly = 0x0000000A,
     NCCH = 0x2345678A,
+    OtherSaveDataGeneral = 0x567890B2,
+    OtherSaveDataPermitted = 0x567890B4,
 };
 
 /// Media types for the archives

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -37,7 +37,7 @@ enum class ArchiveIdCode : u32 {
 };
 
 /// Media types for the archives
-enum class MediaType : u32 { NAND = 0, SDMC = 1 };
+enum class MediaType : u32 { NAND = 0, SDMC = 1, GameCard = 2 };
 
 typedef u64 ArchiveHandle;
 


### PR DESCRIPTION
_DRAFT_

This allows a game/application to access a save data archive that belongs to others. 

There are two types of such save data archive: 

 - `OtherSaveDataGeneral` is often used by save manager application or homebrew save editors. An application needs some special bits set in the exheader to access this archive type. With this archive type the application can read/write any save data stored in SDMC or in the game card. A tested case is my [FS tester](https://github.com/wwylele/3DS-FS-Tester) ([compiled version](https://github.com/wwylele/3DS-FS-Tester/releases/download/1.0/wwylele_fs_tester.cxi)) (Note that the program uses software keyboard to input commands, so you may want to merge [this commit](https://github.com/wwylele/citra/commit/0baf9f8fb6f0cd160d735c59d44a43d005539e2d) so that you can input commands from stdin.)
 - `OtherSaveDataPermitted` is often used by commercial games to transfer data between specific saves, such as transferring between demo and full version. An application doesn't need special bits set in exheader to access this archive type, but it can open only those saves with the title ID specified in the exheader. A tested case is transferring Ash-Greninja from Pokemon Sun&Moon Demo version to Full version.

The permission check is not implemented, for the ease of homebrew application accessing these archives.

_TODO_

 - [x] Error codes