### PR TITLE
Config: auto-select region and language

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -87,7 +87,7 @@ void Config::ReadValues() {
 
     // System
     Settings::values.is_new_3ds = sdl2_config->GetBoolean("System", "is_new_3ds", false);
-    Settings::values.region_value = sdl2_config->GetInteger("System", "region_value", 1);
+    Settings::values.region_value = sdl2_config->GetInteger("System", "region_value", -1);
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Info");

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -97,7 +97,7 @@ use_virtual_sd =
 is_new_3ds =
 
 # The system region that Citra will use during emulation
-# 0: Japan, 1: USA (default), 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
+# -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
 region_value =
 
 [Miscellaneous]

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -71,7 +71,7 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("System");
     Settings::values.is_new_3ds = qt_config->value("is_new_3ds", false).toBool();
-    Settings::values.region_value = qt_config->value("region_value", 1).toInt();
+    Settings::values.region_value = qt_config->value("region_value", -1).toInt();
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -23,13 +23,15 @@ void ConfigureGeneral::setConfiguration() {
     ui->toggle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->toggle_cpu_jit->setChecked(Settings::values.use_cpu_jit);
-    ui->region_combobox->setCurrentIndex(Settings::values.region_value);
+
+    // Note: The first option is "auto" with value -1, so plus one here will do the trick.
+    ui->region_combobox->setCurrentIndex(Settings::values.region_value + 1);
 }
 
 void ConfigureGeneral::applyConfiguration() {
     UISettings::values.gamedir_deepscan = ui->toggle_deepscan->isChecked();
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
-    Settings::values.region_value = ui->region_combobox->currentIndex();
+    Settings::values.region_value = ui->region_combobox->currentIndex() - 1;
     Settings::values.use_cpu_jit = ui->toggle_cpu_jit->isChecked();
     Settings::Apply();
 }

--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -84,6 +84,11 @@
              <widget class="QComboBox" name="region_combobox">
               <item>
                <property name="text">
+                <string>Auto-select</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
                 <string notr="true">JPN</string>
                </property>
               </item>

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -282,6 +282,13 @@ void Init();
 /// Shutdown the config service
 void Shutdown();
 
+/**
+ * Set the region code preferred by the game so that CFG will adjust to it when the region setting
+ * is auto.
+ * @param region_code the preferred region code to set
+ */
+void SetPreferredRegionCode(u32 region_code);
+
 // Utilities for frontend to set config data.
 // Note: before calling these functions, LoadConfigNANDSaveFile should be called,
 // and UpdateConfigNANDSavegame should be called after making changes to config data.

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -11,8 +11,10 @@
 #include "core/file_sys/archive_romfs.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/resource_limit.h"
+#include "core/hle/service/cfg/cfg.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/loader/ncch.h"
+#include "core/loader/smdh.h"
 #include "core/memory.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -325,6 +327,21 @@ ResultStatus AppLoader_NCCH::Load() {
 
     Service::FS::RegisterArchiveType(std::make_unique<FileSys::ArchiveFactory_RomFS>(*this),
                                      Service::FS::ArchiveIdCode::RomFS);
+
+    // Set the preferred region from the region lockout in the SMDH
+    std::vector<u8> smdh;
+    if (ReadIcon(smdh) == ResultStatus::Success && smdh.size() >= sizeof(SMDH)) {
+        u32 region_lockout = reinterpret_cast<SMDH*>(smdh.data())->region_lockout;
+        constexpr u32 REGION_COUNT = 7;
+        for (u32 region = 0; region < REGION_COUNT; ++region) {
+            if (region_lockout & 1) {
+                Service::CFG::SetPreferredRegionCode(region);
+                break;
+            }
+            region_lockout >>= 1;
+        }
+    }
+
     return ResultStatus::Success;
 }
 


### PR DESCRIPTION
Added an option to auto-select region based on game region lockout info. System language will also be override if the region is auto-selected and the chosen language is not available. Also made this option as default. This aims to reduce false positive caused by selecting a wrong region.