### PR TITLE
[WIP] citra-qt: add support for gamepad in input configuration window

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRCS
             configure_graphics.cpp
             configure_system.cpp
             configure_input.cpp
+            configure_input_widget.cpp
             game_list.cpp
             hotkeys.cpp
             main.cpp
@@ -59,6 +60,7 @@ set(HEADERS
             configure_graphics.h
             configure_system.h
             configure_input.h
+            configure_input_widget.h
             game_list.h
             game_list_p.h
             hotkeys.h

--- a/src/citra_qt/configure_input.cpp
+++ b/src/citra_qt/configure_input.cpp
@@ -11,195 +11,60 @@
 #include "common/param_package.h"
 #include "input_common/main.h"
 
-const std::array<std::string, ConfigureInput::ANALOG_SUB_BUTTONS_NUM>
-    ConfigureInput::analog_sub_buttons{{
-        "up", "down", "left", "right", "modifier",
-    }};
-
-static QString getKeyName(int key_code) {
-    switch (key_code) {
-    case Qt::Key_Shift:
-        return QObject::tr("Shift");
-    case Qt::Key_Control:
-        return QObject::tr("Ctrl");
-    case Qt::Key_Alt:
-        return QObject::tr("Alt");
-    case Qt::Key_Meta:
-        return "";
-    default:
-        return QKeySequence(key_code).toString();
-    }
-}
-
-static void SetButtonKey(int key, Common::ParamPackage& button_param) {
-    button_param = Common::ParamPackage{InputCommon::GenerateKeyboardParam(key)};
-}
-
-static void SetAnalogKey(int key, Common::ParamPackage& analog_param,
-                         const std::string& button_name) {
-    if (analog_param.Get("engine", "") != "analog_from_button") {
-        analog_param = {
-            {"engine", "analog_from_button"}, {"modifier_scale", "0.5"},
-        };
-    }
-    analog_param.Set(button_name, InputCommon::GenerateKeyboardParam(key));
-}
-
 ConfigureInput::ConfigureInput(QWidget* parent)
-    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInput>()),
-      timer(std::make_unique<QTimer>()) {
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInput>()) {
 
     ui->setupUi(this);
     setFocusPolicy(Qt::ClickFocus);
 
-    button_map = {
+    button_setters = {
         ui->buttonA,        ui->buttonB,        ui->buttonX,         ui->buttonY,  ui->buttonDpadUp,
         ui->buttonDpadDown, ui->buttonDpadLeft, ui->buttonDpadRight, ui->buttonL,  ui->buttonR,
         ui->buttonStart,    ui->buttonSelect,   ui->buttonZL,        ui->buttonZR, ui->buttonHome,
     };
 
-    analog_map = {{
-        {
-            ui->buttonCircleUp, ui->buttonCircleDown, ui->buttonCircleLeft, ui->buttonCircleRight,
-            ui->buttonCircleMod,
-        },
-        {
-            ui->buttonCStickUp, ui->buttonCStickDown, ui->buttonCStickLeft, ui->buttonCStickRight,
-            nullptr,
-        },
-    }};
-
-    for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
-        if (button_map[button_id])
-            connect(button_map[button_id], &QPushButton::released, [=]() {
-                handleClick(button_map[button_id],
-                            [=](int key) { SetButtonKey(key, buttons_param[button_id]); });
-            });
-    }
-
-    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
-        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
-            if (analog_map[analog_id][sub_button_id] != nullptr) {
-                connect(analog_map[analog_id][sub_button_id], &QPushButton::released, [=]() {
-                    handleClick(analog_map[analog_id][sub_button_id], [=](int key) {
-                        SetAnalogKey(key, analogs_param[analog_id],
-                                     analog_sub_buttons[sub_button_id]);
-                    });
-                });
-            }
-        }
-    }
+    analog_setters = {ui->analogCirclePad, ui->analogCStick};
 
     connect(ui->buttonRestoreDefaults, &QPushButton::released, [this]() { restoreDefaults(); });
 
-    timer->setSingleShot(true);
-    connect(timer.get(), &QTimer::timeout, [this]() {
-        releaseKeyboard();
-        releaseMouse();
-        key_setter = boost::none;
-        updateButtonLabels();
-    });
-
     this->loadConfiguration();
 
-    // TODO(wwylele): enable these when the input emulation for them is implemented
+    // TODO(wwylele): enable these when the input emulation for them is
+    // implemented
     ui->buttonZL->setEnabled(false);
     ui->buttonZR->setEnabled(false);
     ui->buttonHome->setEnabled(false);
-    ui->buttonCStickUp->setEnabled(false);
-    ui->buttonCStickDown->setEnabled(false);
-    ui->buttonCStickLeft->setEnabled(false);
-    ui->buttonCStickRight->setEnabled(false);
 }
 
 void ConfigureInput::applyConfiguration() {
-    std::transform(buttons_param.begin(), buttons_param.end(), Settings::values.buttons.begin(),
-                   [](const Common::ParamPackage& param) { return param.Serialize(); });
-    std::transform(analogs_param.begin(), analogs_param.end(), Settings::values.analogs.begin(),
-                   [](const Common::ParamPackage& param) { return param.Serialize(); });
+    std::transform(button_setters.begin(), button_setters.end(), Settings::values.buttons.begin(),
+                   [](const ButtonSetter* button) { return button->GetInputDeviceParams(); });
+    std::transform(analog_setters.begin(), analog_setters.end(), Settings::values.analogs.begin(),
+                   [](const AnalogSetter* analog) { return analog->GetInputDeviceParams(); });
 
     Settings::Apply();
 }
 
 void ConfigureInput::loadConfiguration() {
-    std::transform(Settings::values.buttons.begin(), Settings::values.buttons.end(),
-                   buttons_param.begin(),
-                   [](const std::string& str) { return Common::ParamPackage(str); });
-    std::transform(Settings::values.analogs.begin(), Settings::values.analogs.end(),
-                   analogs_param.begin(),
-                   [](const std::string& str) { return Common::ParamPackage(str); });
-    updateButtonLabels();
+    for (size_t i = 0; i < button_setters.size(); ++i) {
+        button_setters[i]->SetInputDeviceParams(Settings::values.buttons[i]);
+    }
+    for (size_t i = 0; i < analog_setters.size(); ++i) {
+        analog_setters[i]->SetInputDeviceParams(Settings::values.analogs[i]);
+    }
 }
 
 void ConfigureInput::restoreDefaults() {
-    for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
-        SetButtonKey(Config::default_buttons[button_id], buttons_param[button_id]);
+    for (size_t i = 0; i < button_setters.size(); ++i) {
+        button_setters[i]->SetInputDeviceParams(
+            InputCommon::GenerateKeyboardParam(Config::default_buttons[i]));
     }
 
-    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
-        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
-            SetAnalogKey(Config::default_analogs[analog_id][sub_button_id],
-                         analogs_param[analog_id], analog_sub_buttons[sub_button_id]);
-        }
+    for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; i++) {
+        analog_setters[i]->SetInputDeviceParams(InputCommon::GenerateAnalogParamFromKeys(
+            Config::default_analogs[i][0], Config::default_analogs[i][1],
+            Config::default_analogs[i][2], Config::default_analogs[i][3],
+            Config::default_analogs[i][4], 0.5));
     }
-    updateButtonLabels();
     applyConfiguration();
-}
-
-void ConfigureInput::updateButtonLabels() {
-    QString non_keyboard(tr("[non-keyboard]"));
-
-    auto KeyToText = [&non_keyboard](const Common::ParamPackage& param) {
-        if (param.Get("engine", "") != "keyboard") {
-            return non_keyboard;
-        } else {
-            return getKeyName(param.Get("code", 0));
-        }
-    };
-
-    for (int button = 0; button < Settings::NativeButton::NumButtons; button++) {
-        button_map[button]->setText(KeyToText(buttons_param[button]));
-    }
-
-    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
-        if (analogs_param[analog_id].Get("engine", "") != "analog_from_button") {
-            for (QPushButton* button : analog_map[analog_id]) {
-                if (button)
-                    button->setText(non_keyboard);
-            }
-        } else {
-            for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
-                Common::ParamPackage param(
-                    analogs_param[analog_id].Get(analog_sub_buttons[sub_button_id], ""));
-                if (analog_map[analog_id][sub_button_id])
-                    analog_map[analog_id][sub_button_id]->setText(KeyToText(param));
-            }
-        }
-    }
-}
-
-void ConfigureInput::handleClick(QPushButton* button, std::function<void(int)> new_key_setter) {
-    button->setText(tr("[press key]"));
-    button->setFocus();
-
-    key_setter = new_key_setter;
-
-    grabKeyboard();
-    grabMouse();
-    timer->start(5000); // Cancel after 5 seconds
-}
-
-void ConfigureInput::keyPressEvent(QKeyEvent* event) {
-    releaseKeyboard();
-    releaseMouse();
-
-    if (!key_setter || !event)
-        return;
-
-    if (event->key() != Qt::Key_Escape)
-        (*key_setter)(event->key());
-
-    updateButtonLabels();
-    key_setter = boost::none;
-    timer->stop();
 }

--- a/src/citra_qt/configure_input.h
+++ b/src/citra_qt/configure_input.h
@@ -5,19 +5,11 @@
 #pragma once
 
 #include <array>
-#include <functional>
 #include <memory>
-#include <string>
-#include <QKeyEvent>
 #include <QWidget>
-#include <boost/optional.hpp>
-#include "common/param_package.h"
+#include "citra_qt/configure_input_widget.h"
 #include "core/settings.h"
 #include "ui_configure_input.h"
-
-class QPushButton;
-class QString;
-class QTimer;
 
 namespace Ui {
 class ConfigureInput;
@@ -35,35 +27,12 @@ public:
 private:
     std::unique_ptr<Ui::ConfigureInput> ui;
 
-    std::unique_ptr<QTimer> timer;
-
-    /// This will be the the setting function when an input is awaiting configuration.
-    boost::optional<std::function<void(int)>> key_setter;
-
-    std::array<Common::ParamPackage, Settings::NativeButton::NumButtons> buttons_param;
-    std::array<Common::ParamPackage, Settings::NativeAnalog::NumAnalogs> analogs_param;
-
-    static constexpr int ANALOG_SUB_BUTTONS_NUM = 5;
-
     /// Each button input is represented by a QPushButton.
-    std::array<QPushButton*, Settings::NativeButton::NumButtons> button_map;
-
-    /// Each analog input is represented by five QPushButtons which represents up, down, left, right
-    /// and modifier
-    std::array<std::array<QPushButton*, ANALOG_SUB_BUTTONS_NUM>, Settings::NativeAnalog::NumAnalogs>
-        analog_map;
-
-    static const std::array<std::string, ANALOG_SUB_BUTTONS_NUM> analog_sub_buttons;
+    std::array<ButtonSetter*, Settings::NativeButton::NumButtons> button_setters;
+    std::array<AnalogSetter*, Settings::NativeAnalog::NumAnalogs> analog_setters;
 
     /// Load configuration settings.
     void loadConfiguration();
     /// Restore all buttons to their default values.
     void restoreDefaults();
-    /// Update UI to reflect current configuration.
-    void updateButtonLabels();
-
-    /// Called when the button was pressed.
-    void handleClick(QPushButton* button, std::function<void(int)> new_key_setter);
-    /// Handle key press events.
-    void keyPressEvent(QKeyEvent* event) override;
 };

--- a/src/citra_qt/configure_input.ui
+++ b/src/citra_qt/configure_input.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>370</width>
-    <height>534</height>
+    <width>328</width>
+    <height>424</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,10 +16,10 @@
   <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
     <layout class="QGridLayout" name="gridLayout_7">
-     <item row="0" column="0">
-      <widget class="QGroupBox" name="faceButtons">
+     <item row="2" column="0">
+      <widget class="QGroupBox" name="faceButtons_3">
        <property name="title">
-        <string>Face Buttons</string>
+        <string>Shoulder Buttons</string>
        </property>
        <property name="flat">
         <bool>false</bool>
@@ -27,18 +27,18 @@
        <property name="checkable">
         <bool>false</bool>
        </property>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="verticalLayout">
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="0" column="1">
+         <layout class="QVBoxLayout" name="verticalLayout_14">
           <item>
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="label_19">
             <property name="text">
-             <string>A:</string>
+             <string>R:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonA">
+           <widget class="ButtonSetter" name="buttonR">
             <property name="text">
              <string/>
             </property>
@@ -46,17 +46,17 @@
           </item>
          </layout>
         </item>
-        <item row="0" column="1">
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item row="0" column="0">
+         <layout class="QVBoxLayout" name="verticalLayout_13">
           <item>
-           <widget class="QLabel" name="label_2">
+           <widget class="QLabel" name="label_17">
             <property name="text">
-             <string>B:</string>
+             <string>L:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonB">
+           <widget class="ButtonSetter" name="buttonL">
             <property name="text">
              <string/>
             </property>
@@ -65,16 +65,16 @@
          </layout>
         </item>
         <item row="1" column="0">
-         <layout class="QVBoxLayout" name="verticalLayout_3">
+         <layout class="QVBoxLayout" name="verticalLayout_15">
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_20">
             <property name="text">
-             <string>X:</string>
+             <string>ZL:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonX">
+           <widget class="ButtonSetter" name="buttonZL">
             <property name="text">
              <string/>
             </property>
@@ -83,16 +83,16 @@
          </layout>
         </item>
         <item row="1" column="1">
-         <layout class="QVBoxLayout" name="verticalLayout_4">
+         <layout class="QVBoxLayout" name="verticalLayout_16">
           <item>
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_18">
             <property name="text">
-             <string>Y:</string>
+             <string>ZR:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonY">
+           <widget class="ButtonSetter" name="buttonZR">
             <property name="text">
              <string/>
             </property>
@@ -103,7 +103,43 @@
        </layout>
       </widget>
      </item>
+     <item row="0" column="0">
+      <widget class="QGroupBox" name="faceButtons_4">
+       <property name="title">
+        <string>Circle Pad</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_4">
+        <item row="0" column="0">
+         <widget class="AnalogSetter" name="analogCirclePad" native="true"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
      <item row="0" column="1">
+      <widget class="QGroupBox" name="faceButtons_5">
+       <property name="title">
+        <string>C-Stick</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_5">
+        <item row="0" column="0">
+         <widget class="AnalogSetter" name="analogCStick" native="true"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="1" column="0">
       <widget class="QGroupBox" name="faceButtons_2">
        <property name="title">
         <string>Directional Pad</string>
@@ -125,7 +161,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonDpadUp">
+           <widget class="ButtonSetter" name="buttonDpadUp">
             <property name="text">
              <string/>
             </property>
@@ -143,7 +179,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonDpadDown">
+           <widget class="ButtonSetter" name="buttonDpadDown">
             <property name="text">
              <string/>
             </property>
@@ -161,7 +197,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonDpadLeft">
+           <widget class="ButtonSetter" name="buttonDpadLeft">
             <property name="text">
              <string/>
             </property>
@@ -179,94 +215,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonDpadRight">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QGroupBox" name="faceButtons_3">
-       <property name="title">
-        <string>Shoulder Buttons</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_3">
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="verticalLayout_13">
-          <item>
-           <widget class="QLabel" name="label_17">
-            <property name="text">
-             <string>L:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonL">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="0" column="1">
-         <layout class="QVBoxLayout" name="verticalLayout_14">
-          <item>
-           <widget class="QLabel" name="label_19">
-            <property name="text">
-             <string>R:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonR">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0">
-         <layout class="QVBoxLayout" name="verticalLayout_15">
-          <item>
-           <widget class="QLabel" name="label_20">
-            <property name="text">
-             <string>ZL:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonZL">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="1">
-         <layout class="QVBoxLayout" name="verticalLayout_16">
-          <item>
-           <widget class="QLabel" name="label_18">
-            <property name="text">
-             <string>ZR:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonZR">
+           <widget class="ButtonSetter" name="buttonDpadRight">
             <property name="text">
              <string/>
             </property>
@@ -278,9 +227,9 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QGroupBox" name="faceButtons_4">
+      <widget class="QGroupBox" name="faceButtons">
        <property name="title">
-        <string>Circle Pad</string>
+        <string>Face Buttons</string>
        </property>
        <property name="flat">
         <bool>false</bool>
@@ -288,18 +237,18 @@
        <property name="checkable">
         <bool>false</bool>
        </property>
-       <layout class="QGridLayout" name="gridLayout_4">
+       <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <layout class="QVBoxLayout" name="verticalLayout_17">
+         <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <widget class="QLabel" name="label_21">
+           <widget class="QLabel" name="label">
             <property name="text">
-             <string>Left:</string>
+             <string>A:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonCircleLeft">
+           <widget class="ButtonSetter" name="buttonA">
             <property name="text">
              <string/>
             </property>
@@ -308,103 +257,16 @@
          </layout>
         </item>
         <item row="0" column="1">
-         <layout class="QVBoxLayout" name="verticalLayout_18">
+         <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <widget class="QLabel" name="label_23">
+           <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>Right:</string>
+             <string>B:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonCircleRight">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0">
-         <layout class="QVBoxLayout" name="verticalLayout_19">
-          <item>
-           <widget class="QLabel" name="label_24">
-            <property name="text">
-             <string>Up:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonCircleUp">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="1">
-         <layout class="QVBoxLayout" name="verticalLayout_20">
-          <item>
-           <widget class="QLabel" name="label_22">
-            <property name="text">
-             <string>Down:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonCircleDown">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QGroupBox" name="faceButtons_5">
-       <property name="title">
-        <string>C-Stick</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_5">
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="verticalLayout_21">
-          <item>
-           <widget class="QLabel" name="label_25">
-            <property name="text">
-             <string>Left:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonCStickLeft">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="0" column="1">
-         <layout class="QVBoxLayout" name="verticalLayout_22">
-          <item>
-           <widget class="QLabel" name="label_27">
-            <property name="text">
-             <string>Right:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonCStickRight">
+           <widget class="ButtonSetter" name="buttonB">
             <property name="text">
              <string/>
             </property>
@@ -413,16 +275,16 @@
          </layout>
         </item>
         <item row="1" column="0">
-         <layout class="QVBoxLayout" name="verticalLayout_23">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
-           <widget class="QLabel" name="label_28">
+           <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Up:</string>
+             <string>X:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonCStickUp">
+           <widget class="ButtonSetter" name="buttonX">
             <property name="text">
              <string/>
             </property>
@@ -431,16 +293,16 @@
          </layout>
         </item>
         <item row="1" column="1">
-         <layout class="QVBoxLayout" name="verticalLayout_24">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="QLabel" name="label_26">
+           <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Down:</string>
+             <string>Y:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonCStickDown">
+           <widget class="ButtonSetter" name="buttonY">
             <property name="text">
              <string/>
             </property>
@@ -473,7 +335,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonStart">
+           <widget class="ButtonSetter" name="buttonStart">
             <property name="text">
              <string/>
             </property>
@@ -491,7 +353,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonSelect">
+           <widget class="ButtonSetter" name="buttonSelect">
             <property name="text">
              <string/>
             </property>
@@ -509,25 +371,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonHome">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="1">
-         <layout class="QVBoxLayout" name="verticalLayout_28">
-          <item>
-           <widget class="QLabel" name="label_36">
-            <property name="text">
-             <string>Circle Mod:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonCircleMod">
+           <widget class="ButtonSetter" name="buttonHome">
             <property name="text">
              <string/>
             </property>
@@ -587,6 +431,20 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ButtonSetter</class>
+   <extends>QPushButton</extends>
+   <header>configure_input_widget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>AnalogSetter</class>
+   <extends>QWidget</extends>
+   <header>configure_input_widget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/configure_input_widget.cpp
+++ b/src/citra_qt/configure_input_widget.cpp
@@ -1,0 +1,252 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QRadioButton>
+#include <QTimer>
+#include <QVBoxLayout>
+#include "citra_qt/configure_input_widget.h"
+#include "common/param_package.h"
+#include "input_common/main.h"
+
+SDLButtonListener::SDLButtonListener()
+    : listener(new InputCommon::SDL::Listener(
+          [this](const std::string& button_params) {
+              emit InputDeviceParamsReceived(QString::fromStdString(button_params));
+          },
+          [](const std::string& analog_params) {
+
+          })) {}
+
+SDLButtonListener::~SDLButtonListener() {
+    // ensure the listener is destructed before the signal-slot framework get destructed
+    listener = nullptr;
+}
+
+SDLAnalogListener::SDLAnalogListener()
+    : listener(new InputCommon::SDL::Listener(
+          [](const std::string& button_params) {
+
+          },
+          [this](const std::string& analog_params) {
+              emit InputDeviceParamsReceived(QString::fromStdString(analog_params));
+          })) {}
+
+SDLAnalogListener::~SDLAnalogListener() {
+    // ensure the listener is destructed before the signal-slot framework get destructed
+    listener = nullptr;
+}
+
+static QString getKeyName(int key_code) {
+    switch (key_code) {
+    case Qt::Key_Shift:
+        return QObject::tr("Shift");
+    case Qt::Key_Control:
+        return QObject::tr("Ctrl");
+    case Qt::Key_Alt:
+        return QObject::tr("Alt");
+    case Qt::Key_Meta:
+        return "";
+    default:
+        return QKeySequence(key_code).toString();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+InputDeviceSettingButton::InputDeviceSettingButton(QWidget* parent)
+    : QPushButton(parent), timer(new QTimer()) {
+    connect(this, &QPushButton::released, this, &InputDeviceSettingButton::ToggleSetInputDevice);
+    connect(timer.get(), &QTimer::timeout, [=]() { EndSetInputDevice(""); });
+    timer->setSingleShot(true);
+}
+
+void InputDeviceSettingButton::SetInputDeviceParams(const std::string& params) {
+    param_package = Common::ParamPackage(params);
+    UpdateText();
+}
+
+std::string InputDeviceSettingButton::GetInputDeviceParams() const {
+    return param_package.Serialize();
+}
+
+void InputDeviceSettingButton::ToggleSetInputDevice() {
+    if (is_listening) {
+        EndSetInputDevice("");
+    } else {
+        BeginSetInputDevice();
+    }
+}
+
+void InputDeviceSettingButton::BeginSetInputDevice() {
+    setText(GetWaitingText());
+    setFocus();
+
+    sdl_listener = std::unique_ptr<SDLListener>(CreateListener());
+    connect(sdl_listener.get(), &SDLListener::InputDeviceParamsReceived, this,
+            [=](const QString& params) { EndSetInputDevice(params.toStdString()); },
+            Qt::QueuedConnection);
+
+    timer->start(5000);
+
+    grabKeyboard();
+    grabMouse();
+    is_listening = true;
+}
+
+void InputDeviceSettingButton::EndSetInputDevice(const std::string& params) {
+    releaseKeyboard();
+    releaseMouse();
+    is_listening = false;
+
+    timer->stop();
+
+    sdl_listener = nullptr;
+
+    if (params != "") {
+        SetInputDeviceParams(params);
+    } else {
+        UpdateText();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+ButtonSetter::ButtonSetter(QWidget* parent) : InputDeviceSettingButton(parent) {}
+
+SDLListener* ButtonSetter::CreateListener() {
+    return new SDLButtonListener;
+}
+
+void ButtonSetter::UpdateText() {
+    if (param_package.Get("engine", "") == "keyboard") {
+        setText(getKeyName(param_package.Get("code", 0)));
+    } else if (param_package.Get("engine", "") == "sdl") {
+        QString joystick = QString::fromStdString(param_package.Get("joystick", ""));
+        if (param_package.Has("hat")) {
+            setText(QString("j%1/h%2/%3")
+                        .arg(joystick, QString::fromStdString(param_package.Get("hat", "")),
+                             QString::fromStdString(param_package.Get("direction", ""))));
+        } else {
+            setText(QString("j%1/b%2").arg(
+                joystick, QString::fromStdString(param_package.Get("button", ""))));
+        }
+    } else {
+        setText(tr("[unknown]"));
+    }
+}
+
+void ButtonSetter::keyPressEvent(QKeyEvent* event) {
+    if (is_listening) {
+        EndSetInputDevice(InputCommon::GenerateKeyboardParam(event->key()));
+    }
+}
+
+QString ButtonSetter::GetWaitingText() const {
+    return tr("[press key]");
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+AxisAnalogSetter::AxisAnalogSetter(QWidget* parent) : InputDeviceSettingButton(parent) {}
+
+SDLListener* AxisAnalogSetter::CreateListener() {
+    return new SDLAnalogListener;
+}
+
+void AxisAnalogSetter::UpdateText() {
+    if (param_package.Get("engine", "") == "sdl") {
+        setText(QString("j%1/%2,%3")
+                    .arg(QString::fromStdString(param_package.Get("joystick", "")),
+                         QString::fromStdString(param_package.Get("axis_x", "")),
+                         QString::fromStdString(param_package.Get("axis_y", ""))));
+    } else {
+        setText(tr("[unknown]"));
+    }
+}
+
+QString AxisAnalogSetter::GetWaitingText() const {
+    return tr("[move stick]");
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+AnalogSetter::AnalogSetter(QWidget* parent) : QWidget(parent) {
+    QVBoxLayout* main_layout = new QVBoxLayout();
+    QHBoxLayout* radio_layout = new QHBoxLayout();
+    main_layout->addLayout(radio_layout);
+    radio_from_buttons = new QRadioButton(tr("buttons"));
+    radio_from_axes = new QRadioButton(tr("gamepad"));
+    radio_others = new QRadioButton(tr("others"));
+    radio_layout->addWidget(radio_from_buttons);
+    radio_layout->addWidget(radio_from_axes);
+    radio_layout->addWidget(radio_others);
+
+    page_from_buttons = new QWidget();
+    QGridLayout* layout_from_buttons = new QGridLayout();
+    button_up = new ButtonSetter();
+    button_down = new ButtonSetter();
+    button_left = new ButtonSetter();
+    button_right = new ButtonSetter();
+    button_mod = new ButtonSetter();
+    layout_from_buttons->addWidget(button_up, 0, 1);
+    layout_from_buttons->addWidget(button_down, 2, 1);
+    layout_from_buttons->addWidget(button_left, 1, 0);
+    layout_from_buttons->addWidget(button_right, 1, 2);
+    layout_from_buttons->addWidget(button_mod, 1, 1);
+    page_from_buttons->setLayout(layout_from_buttons);
+    page_from_buttons->setVisible(false);
+
+    page_from_axes = new AxisAnalogSetter();
+    page_from_axes->setVisible(false);
+
+    main_layout->addWidget(page_from_buttons);
+    main_layout->addWidget(page_from_axes);
+
+    setLayout(main_layout);
+
+    connect(radio_from_buttons, &QRadioButton::toggled, this, &AnalogSetter::OnPageChanged);
+    connect(radio_from_axes, &QRadioButton::toggled, this, &AnalogSetter::OnPageChanged);
+    connect(radio_others, &QRadioButton::toggled, this, &AnalogSetter::OnPageChanged);
+}
+
+void AnalogSetter::SetInputDeviceParams(const std::string& params) {
+    init_param_package = Common::ParamPackage(params);
+    if (init_param_package.Get("engine", "") == "analog_from_button") {
+        radio_from_buttons->setChecked(true);
+        button_up->SetInputDeviceParams(init_param_package.Get("up", ""));
+        button_down->SetInputDeviceParams(init_param_package.Get("down", ""));
+        button_left->SetInputDeviceParams(init_param_package.Get("left", ""));
+        button_right->SetInputDeviceParams(init_param_package.Get("right", ""));
+        button_mod->SetInputDeviceParams(init_param_package.Get("modifier", ""));
+    } else if (init_param_package.Get("engine", "") == "sdl") {
+        radio_from_axes->setChecked(true);
+        page_from_axes->SetInputDeviceParams(params);
+    } else {
+        radio_others->setChecked(true);
+    }
+}
+
+std::string AnalogSetter::GetInputDeviceParams() const {
+    if (radio_from_buttons->isChecked()) {
+        return Common::ParamPackage{
+            {"engine", "analog_from_button"},
+            {"up", button_up->GetInputDeviceParams()},
+            {"down", button_down->GetInputDeviceParams()},
+            {"left", button_left->GetInputDeviceParams()},
+            {"right", button_right->GetInputDeviceParams()},
+            {"modifier", button_mod->GetInputDeviceParams()},
+            {"modifier_scale", "0.5"},
+        }.Serialize();
+    } else if (radio_from_axes->isChecked()) {
+        return page_from_axes->GetInputDeviceParams();
+    }
+
+    return init_param_package.Serialize();
+}
+
+void AnalogSetter::OnPageChanged() {
+    page_from_buttons->setVisible(radio_from_buttons->isChecked());
+    page_from_axes->setVisible(radio_from_axes->isChecked());
+}

--- a/src/citra_qt/configure_input_widget.h
+++ b/src/citra_qt/configure_input_widget.h
@@ -1,0 +1,117 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <QKeyEvent>
+#include <QPushButton>
+#include "common/param_package.h"
+#include "input_common/sdl/listener.h"
+
+class SDLListener : public QObject {
+    Q_OBJECT
+
+signals:
+    void InputDeviceParamsReceived(const QString& button_params);
+};
+
+class SDLButtonListener : public SDLListener {
+    Q_OBJECT
+public:
+    SDLButtonListener();
+    ~SDLButtonListener();
+
+private:
+    std::unique_ptr<InputCommon::SDL::Listener> listener;
+};
+
+class SDLAnalogListener : public SDLListener {
+    Q_OBJECT
+public:
+    SDLAnalogListener();
+    ~SDLAnalogListener();
+
+private:
+    std::unique_ptr<InputCommon::SDL::Listener> listener;
+};
+
+class InputDeviceSettingButton : public QPushButton {
+    Q_OBJECT
+
+public:
+    explicit InputDeviceSettingButton(QWidget* parent = Q_NULLPTR);
+    void SetInputDeviceParams(const std::string& params);
+    std::string GetInputDeviceParams() const;
+
+protected:
+    virtual SDLListener* CreateListener() = 0;
+
+    Common::ParamPackage param_package;
+    std::unique_ptr<QTimer> timer;
+    std::unique_ptr<SDLListener> sdl_listener;
+    bool is_listening = false;
+
+    void ToggleSetInputDevice();
+    void BeginSetInputDevice();
+    void EndSetInputDevice(const std::string& params);
+    virtual void UpdateText() = 0;
+    virtual QString GetWaitingText() const = 0;
+};
+
+class ButtonSetter : public InputDeviceSettingButton {
+    Q_OBJECT
+
+public:
+    explicit ButtonSetter(QWidget* parent = Q_NULLPTR);
+
+protected:
+    SDLListener* CreateListener() override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void UpdateText() override;
+    QString GetWaitingText() const override;
+};
+
+class AxisAnalogSetter : public InputDeviceSettingButton {
+    Q_OBJECT
+
+public:
+    explicit AxisAnalogSetter(QWidget* parent = Q_NULLPTR);
+
+protected:
+    SDLListener* CreateListener() override;
+    void UpdateText() override;
+    QString GetWaitingText() const override;
+};
+
+class QRadioButton;
+
+class AnalogSetter : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit AnalogSetter(QWidget* parent = Q_NULLPTR);
+    void SetInputDeviceParams(const std::string& params);
+    std::string GetInputDeviceParams() const;
+
+private:
+    QRadioButton* radio_from_buttons;
+    QRadioButton* radio_from_axes;
+    QRadioButton* radio_others;
+
+    QWidget* page_from_buttons;
+    AxisAnalogSetter* page_from_axes;
+
+    ButtonSetter* button_up;
+    ButtonSetter* button_down;
+    ButtonSetter* button_left;
+    ButtonSetter* button_right;
+    ButtonSetter* button_mod;
+
+    Common::ParamPackage init_param_package;
+
+    void OnPageChanged();
+};

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -2,12 +2,14 @@ set(SRCS
             analog_from_button.cpp
             keyboard.cpp
             main.cpp
+            sdl/listener.cpp
             )
 
 set(HEADERS
             analog_from_button.h
             keyboard.h
             main.h
+            sdl/listener.h
             )
 
 if(SDL2_FOUND)

--- a/src/input_common/sdl/listener.cpp
+++ b/src/input_common/sdl/listener.cpp
@@ -1,0 +1,136 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <atomic>
+#include <cstdlib>
+#include <thread>
+#include <unordered_map>
+#ifdef HAVE_SDL2
+#include <SDL.h>
+#endif
+#include "common/logging/log.h"
+#include "common/param_package.h"
+#include "input_common/sdl/listener.h"
+
+namespace InputCommon {
+namespace SDL {
+
+#ifdef HAVE_SDL2
+
+class ListenerDetail {
+public:
+    ListenerDetail(ParamsHandler button_params_handler_, ParamsHandler analog_params_handler_)
+        : button_params_handler(button_params_handler_),
+          analog_params_handler(analog_params_handler_) {
+        if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0) {
+            LOG_CRITICAL(Input, "SDL_InitSubSystem(SDL_INIT_JOYSTICK) failed with: %s",
+                         SDL_GetError());
+        }
+
+        SDL_JoystickEventState(SDL_ENABLE);
+
+        const int num_joysticks = SDL_NumJoysticks();
+        for (int i = 0; i < num_joysticks; ++i) {
+            SDL_Joystick* joystick = SDL_JoystickOpen(i);
+            if (!joystick) {
+                LOG_ERROR(Input, "SDL_JoystickOpen(%d) failed with: %s", i, SDL_GetError());
+            } else {
+                joysticks[joystick] = i;
+            }
+        }
+
+        listen_button_stop.store(false);
+
+        listen_button_thread =
+            std::make_unique<std::thread>(&ListenerDetail::ListenButtonThread, this);
+    }
+
+    ~ListenerDetail() {
+        listen_button_stop.store(true);
+        listen_button_thread->join();
+
+        for (auto& pair : joysticks) {
+            SDL_JoystickClose(pair.first);
+        }
+
+        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
+    }
+
+private:
+    ParamsHandler button_params_handler;
+    ParamsHandler analog_params_handler;
+    std::unordered_map<SDL_Joystick*, int> joysticks;
+    std::atomic<bool> listen_button_stop;
+    std::unique_ptr<std::thread> listen_button_thread;
+
+    void ListenButtonThread() {
+        LOG_INFO(Input, "called");
+        while (!listen_button_stop.load()) {
+            SDL_Event event;
+            while (SDL_PollEvent(&event)) {
+                switch (event.type) {
+                case SDL_JOYBUTTONDOWN: {
+                    SDL_Joystick* joystick = SDL_JoystickFromInstanceID(event.jbutton.which);
+                    int index = joysticks.at(joystick);
+                    button_params_handler(Common::ParamPackage{
+                        {"engine", "sdl"},
+                        {"joystick", std::to_string(index)},
+                        {"button", std::to_string(event.jbutton.button)},
+                    }.Serialize());
+                    break;
+                }
+                case SDL_JOYHATMOTION: {
+                    SDL_Joystick* joystick = SDL_JoystickFromInstanceID(event.jhat.which);
+                    int index = joysticks.at(joystick);
+                    std::string direction;
+                    if (event.jhat.value == SDL_HAT_UP) {
+                        direction = "up";
+                    } else if (event.jhat.value == SDL_HAT_DOWN) {
+                        direction = "down";
+                    } else if (event.jhat.value == SDL_HAT_LEFT) {
+                        direction = "left";
+                    } else if (event.jhat.value == SDL_HAT_RIGHT) {
+                        direction = "right";
+                    } else {
+                        break;
+                    }
+                    button_params_handler(Common::ParamPackage{
+                        {"engine", "sdl"},
+                        {"joystick", std::to_string(index)},
+                        {"hat", std::to_string(event.jhat.hat)},
+                        {"direction", direction},
+                    }.Serialize());
+                    break;
+                }
+                case SDL_JOYAXISMOTION: {
+                    if (std::abs(event.jaxis.value) > 15000) {
+                        SDL_Joystick* joystick = SDL_JoystickFromInstanceID(event.jaxis.which);
+                        int index = joysticks.at(joystick);
+                        int axis = event.jaxis.axis / 2 * 2;
+                        analog_params_handler(Common::ParamPackage{
+                            {"engine", "sdl"},
+                            {"joystick", std::to_string(index)},
+                            {"axis_x", std::to_string(axis)},
+                            {"axis_y", std::to_string(axis + 1)},
+                        }.Serialize());
+                    }
+                } break;
+                }
+            }
+        }
+    }
+};
+
+#endif // HAVE_SDL2
+
+Listener::Listener(ParamsHandler button_params_handler, ParamsHandler analog_params_handler) {
+#ifdef HAVE_SDL2
+    detail = std::make_unique<ListenerDetail>(button_params_handler, analog_params_handler);
+#endif
+}
+
+Listener::~Listener() = default;
+
+} // namespace SDL
+} // namespace InputCommon

--- a/src/input_common/sdl/listener.h
+++ b/src/input_common/sdl/listener.h
@@ -1,0 +1,28 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace InputCommon {
+namespace SDL {
+
+class ListenerDetail;
+
+using ParamsHandler = std::function<void(const std::string& params)>;
+
+class Listener {
+public:
+    Listener(ParamsHandler button_params_handler, ParamsHandler analog_params_handler);
+    ~Listener();
+
+private:
+    std::unique_ptr<ListenerDetail> detail;
+};
+
+} // namespace SDL
+} // namespace InputCommon


### PR DESCRIPTION
TODO

- [x] receive hat input
- [x] analog input configuration rework
- [ ] layout rework?
- [ ] `GetDescription` method for `Factory` ?
