### PR TITLE
gl_rasterizer_cache: fix using_depth_fb

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -542,10 +542,11 @@ RasterizerCacheOpenGL::GetFramebufferSurfaces(
             config.GetDepthBufferPhysicalAddress(),
             fb_area * Pica::FramebufferRegs::BytesPerDepthPixel(config.depth_format));
     bool using_color_fb = config.GetColorBufferPhysicalAddress() != 0;
-    bool using_depth_fb =
-        config.GetDepthBufferPhysicalAddress() != 0 &&
-        (regs.framebuffer.output_merger.depth_test_enable ||
-         regs.framebuffer.output_merger.depth_write_enable || !framebuffers_overlap);
+    bool depth_write_enable = regs.framebuffer.output_merger.depth_write_enable &&
+                              regs.framebuffer.framebuffer.allow_depth_stencil_write;
+    bool using_depth_fb = config.GetDepthBufferPhysicalAddress() != 0 &&
+                          (regs.framebuffer.output_merger.depth_test_enable || depth_write_enable ||
+                           !framebuffers_overlap);
 
     if (framebuffers_overlap && using_color_fb && using_depth_fb) {
         LOG_CRITICAL(Render_OpenGL, "Color and depth framebuffer memory regions overlap; "


### PR DESCRIPTION
Changed on of the depth buffer condition from `depth_write_enable` to `(depth_write_enable &&  allow_depth_stencil_write)`. In other places in the code base, these two bools are always `&&` together, so I assume this one is just forget to add.

This eliminates the "Color and depth framebuffer memory regions overlap" spam in smash bros, where the game sets the depth buffer address the same as the color buffer. The relevant command list is
```
GPUREG_STENCIL_TEST	105	1111	ff00ff10
GPUREG_STENCIL_OP	106	1111	00000000	
GPUREG_DEPTH_COLOR_MASK	107	1111	00001f40	 // depth_test_enable = false, depth_write_enable = true
GPUREG_DEPTHMAP_ENABLE	06d	1111	00000001	
GPUREG_DEPTHMAP_SCALE	04d	1111	00bf0000	
GPUREG_DEPTHMAP_OFFSET	04e	1111	00000000	
GPUREG_FRAMEBUFFER_FLUSH	111	1111	00000001	
GPUREG_FRAMEBUFFER_INVALIDATE	110	1111	00000001	
GPUREG_COLORBUFFER_READ	112	0001	0000000f	
GPUREG_COLORBUFFER_WRITE	113	0001	0000000f	
GPUREG_DEPTHBUFFER_READ	114	0001	00000000	
GPUREG_DEPTHBUFFER_WRITE	115	0001	00000000	// allow_depth_stencil_write = false
```