### PR TITLE
Please leave if you are making unofficial build, thanks!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,11 +295,18 @@ function(create_directory_groups)
     endforeach()
 endfunction()
 
-# generate git revision information
+# Gets a UTC timstamp and sets the provided variable to it
+function(get_timestamp _var)
+    string(TIMESTAMP timestamp UTC)
+    set(${_var} "${timestamp}" PARENT_SCOPE)
+endfunction()
+
+# generate git/build information
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REF_SPEC GIT_REV)
 git_describe(GIT_DESC --always --long --dirty)
 git_branch_name(GIT_BRANCH)
+get_timestamp(BUILD_DATE)
 
 enable_testing()
 add_subdirectory(externals)

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -311,7 +311,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 
     if (!gladLoadGL()) {
         QMessageBox::critical(this, tr("Error while initializing OpenGL 3.3 Core!"),
-                              tr("Your GPU may not support OpenGL 3.3, or you do not"
+                              tr("Your GPU may not support OpenGL 3.3, or you do not "
                                  "have the latest graphics driver."));
         return false;
     }

--- a/src/common/quaternion.h
+++ b/src/common/quaternion.h
@@ -30,6 +30,11 @@ public:
         return {xyz * other.w + other.xyz * w + Cross(xyz, other.xyz),
                 w * other.w - Dot(xyz, other.xyz)};
     }
+
+    Quaternion<T> Normalized() const {
+        T length = std::sqrt(xyz.Length2() + w * w);
+        return {xyz / length, w / length};
+    }
 };
 
 template <typename T>

--- a/src/common/scm_rev.cpp.in
+++ b/src/common/scm_rev.cpp.in
@@ -8,6 +8,7 @@
 #define GIT_BRANCH   "@GIT_BRANCH@"
 #define GIT_DESC     "@GIT_DESC@"
 #define BUILD_NAME   "@REPO_NAME@"
+#define BUILD_DATE   "@BUILD_DATE@"
 
 namespace Common {
 
@@ -15,6 +16,7 @@ const char g_scm_rev[]      = GIT_REV;
 const char g_scm_branch[]   = GIT_BRANCH;
 const char g_scm_desc[]     = GIT_DESC;
 const char g_build_name[]   = BUILD_NAME;
+const char g_build_date[]   = BUILD_DATE;
 
 } // namespace
 

--- a/src/common/scm_rev.h
+++ b/src/common/scm_rev.h
@@ -10,5 +10,6 @@ extern const char g_scm_rev[];
 extern const char g_scm_branch[];
 extern const char g_scm_desc[];
 extern const char g_build_name[];
+extern const char g_build_date[];
 
 } // namespace

--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include <cmath>
-#include <type_traits>
 
 namespace Math {
 
@@ -90,7 +89,7 @@ public:
         x -= other.x;
         y -= other.y;
     }
-    template <typename Q = T, class = typename std::enable_if<std::is_signed<Q>::value>::type>
+
     Vec2<decltype(-T{})> operator-() const {
         return MakeVec(-x, -y);
     }
@@ -247,7 +246,7 @@ public:
         y -= other.y;
         z -= other.z;
     }
-    template <typename Q = T, class = typename std::enable_if<std::is_signed<Q>::value>::type>
+
     Vec3<decltype(-T{})> operator-() const {
         return MakeVec(-x, -y, -z);
     }
@@ -462,7 +461,7 @@ public:
         z -= other.z;
         w -= other.w;
     }
-    template <typename Q = T, class = typename std::enable_if<std::is_signed<Q>::value>::type>
+
     Vec4<decltype(-T{})> operator-() const {
         return MakeVec(-x, -y, -z, -w);
     }

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -7,16 +7,13 @@
 #include <memory>
 #include <string>
 #include "common/common_types.h"
+#include "core/loader/loader.h"
 #include "core/memory.h"
 #include "core/perf_stats.h"
 #include "core/telemetry_session.h"
 
 class EmuWindow;
 class ARM_Interface;
-
-namespace Loader {
-class AppLoader;
-}
 
 namespace Core {
 
@@ -117,6 +114,10 @@ public:
 
     const std::string& GetStatusDetails() const {
         return status_details;
+    }
+
+    Loader::AppLoader& GetAppLoader() const {
+        return *app_loader;
     }
 
 private:

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -121,7 +121,25 @@ ResultCode SDMCArchive::DeleteFile(const Path& path) const {
 }
 
 ResultCode SDMCArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
-    if (FileUtil::Rename(mount_point + src_path.AsString(), mount_point + dest_path.AsString())) {
+    const PathParser path_parser_src(src_path);
+
+    // TODO: Verify these return codes with HW
+    if (!path_parser_src.IsValid()) {
+        LOG_ERROR(Service_FS, "Invalid src path %s", src_path.DebugStr().c_str());
+        return ERROR_INVALID_PATH;
+    }
+
+    const PathParser path_parser_dest(dest_path);
+
+    if (!path_parser_dest.IsValid()) {
+        LOG_ERROR(Service_FS, "Invalid dest path %s", dest_path.DebugStr().c_str());
+        return ERROR_INVALID_PATH;
+    }
+
+    const auto src_path_full = path_parser_src.BuildHostPath(mount_point);
+    const auto dest_path_full = path_parser_dest.BuildHostPath(mount_point);
+
+    if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
     }
 
@@ -260,8 +278,27 @@ ResultCode SDMCArchive::CreateDirectory(const Path& path) const {
 }
 
 ResultCode SDMCArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
-    if (FileUtil::Rename(mount_point + src_path.AsString(), mount_point + dest_path.AsString()))
+    const PathParser path_parser_src(src_path);
+
+    // TODO: Verify these return codes with HW
+    if (!path_parser_src.IsValid()) {
+        LOG_ERROR(Service_FS, "Invalid src path %s", src_path.DebugStr().c_str());
+        return ERROR_INVALID_PATH;
+    }
+
+    const PathParser path_parser_dest(dest_path);
+
+    if (!path_parser_dest.IsValid()) {
+        LOG_ERROR(Service_FS, "Invalid dest path %s", dest_path.DebugStr().c_str());
+        return ERROR_INVALID_PATH;
+    }
+
+    const auto src_path_full = path_parser_src.BuildHostPath(mount_point);
+    const auto dest_path_full = path_parser_dest.BuildHostPath(mount_point);
+
+    if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
+    }
 
     // TODO(yuriks): This code probably isn't right, it'll return a Status even if the file didn't
     // exist or similar. Verify.

--- a/src/core/file_sys/savedata_archive.cpp
+++ b/src/core/file_sys/savedata_archive.cpp
@@ -106,7 +106,25 @@ ResultCode SaveDataArchive::DeleteFile(const Path& path) const {
 }
 
 ResultCode SaveDataArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
-    if (FileUtil::Rename(mount_point + src_path.AsString(), mount_point + dest_path.AsString())) {
+    const PathParser path_parser_src(src_path);
+
+    // TODO: Verify these return codes with HW
+    if (!path_parser_src.IsValid()) {
+        LOG_ERROR(Service_FS, "Invalid src path %s", src_path.DebugStr().c_str());
+        return ERROR_INVALID_PATH;
+    }
+
+    const PathParser path_parser_dest(dest_path);
+
+    if (!path_parser_dest.IsValid()) {
+        LOG_ERROR(Service_FS, "Invalid dest path %s", dest_path.DebugStr().c_str());
+        return ERROR_INVALID_PATH;
+    }
+
+    const auto src_path_full = path_parser_src.BuildHostPath(mount_point);
+    const auto dest_path_full = path_parser_dest.BuildHostPath(mount_point);
+
+    if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
     }
 
@@ -247,8 +265,27 @@ ResultCode SaveDataArchive::CreateDirectory(const Path& path) const {
 }
 
 ResultCode SaveDataArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
-    if (FileUtil::Rename(mount_point + src_path.AsString(), mount_point + dest_path.AsString()))
+    const PathParser path_parser_src(src_path);
+
+    // TODO: Verify these return codes with HW
+    if (!path_parser_src.IsValid()) {
+        LOG_ERROR(Service_FS, "Invalid src path %s", src_path.DebugStr().c_str());
+        return ERROR_INVALID_PATH;
+    }
+
+    const PathParser path_parser_dest(dest_path);
+
+    if (!path_parser_dest.IsValid()) {
+        LOG_ERROR(Service_FS, "Invalid dest path %s", dest_path.DebugStr().c_str());
+        return ERROR_INVALID_PATH;
+    }
+
+    const auto src_path_full = path_parser_src.BuildHostPath(mount_point);
+    const auto dest_path_full = path_parser_dest.BuildHostPath(mount_point);
+
+    if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
+    }
 
     // TODO(yuriks): This code probably isn't right, it'll return a Status even if the file didn't
     // exist or similar. Verify.

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -75,6 +75,10 @@ void Initialize(Service::Interface* self) {
 void GetSharedFont(Service::Interface* self) {
     IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x44, 0, 0); // 0x00440000
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
+
+    // Log in telemetry if the game uses the shared font
+    Core::Telemetry().AddField(Telemetry::FieldType::Session, "RequiresSharedFont", true);
+
     if (!shared_font_loaded) {
         LOG_ERROR(Service_APT, "shared font file missing - go dump it from your 3ds");
         rb.Push<u32>(-1); // TODO: Find the right error code

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -681,7 +681,7 @@ void GenerateConsoleUniqueId(u32& random_number, u64& console_id) {
     CryptoPP::AutoSeededRandomPool rng;
     random_number = rng.GenerateWord32(0, 0xFFFF);
     u64_le local_friend_code_seed;
-    rng.GenerateBlock(reinterpret_cast<byte*>(&local_friend_code_seed),
+    rng.GenerateBlock(reinterpret_cast<CryptoPP::byte*>(&local_friend_code_seed),
                       sizeof(local_friend_code_seed));
     console_id = (local_friend_code_seed & 0x3FFFFFFFF) | (static_cast<u64>(random_number) << 48);
 }

--- a/src/core/hle/service/dlp/dlp_clnt.cpp
+++ b/src/core/hle/service/dlp/dlp_clnt.cpp
@@ -8,7 +8,26 @@ namespace Service {
 namespace DLP {
 
 const Interface::FunctionInfo FunctionTable[] = {
-    {0x000100C3, nullptr, "Initialize"}, {0x00110000, nullptr, "GetWirelessRebootPassphrase"},
+    {0x000100C3, nullptr, "Initialize"},
+    {0x00020000, nullptr, "Finalize"},
+    {0x00030000, nullptr, "GetEventDesc"},
+    {0x00040000, nullptr, "GetChannel"},
+    {0x00050180, nullptr, "StartScan"},
+    {0x00060000, nullptr, "StopScan"},
+    {0x00070080, nullptr, "GetServerInfo"},
+    {0x00080100, nullptr, "GetTitleInfo"},
+    {0x00090040, nullptr, "GetTitleInfoInOrder"},
+    {0x000A0080, nullptr, "DeleteScanInfo"},
+    {0x000B0100, nullptr, "PrepareForSystemDownload"},
+    {0x000C0000, nullptr, "StartSystemDownload"},
+    {0x000D0100, nullptr, "StartTitleDownload"},
+    {0x000E0000, nullptr, "GetMyStatus"},
+    {0x000F0040, nullptr, "GetConnectingNodes"},
+    {0x00100040, nullptr, "GetNodeInfo"},
+    {0x00110000, nullptr, "GetWirelessRebootPassphrase"},
+    {0x00120000, nullptr, "StopSession"},
+    {0x00130100, nullptr, "GetCupVersion"},
+    {0x00140100, nullptr, "GetDupAvailability"},
 };
 
 DLP_CLNT_Interface::DLP_CLNT_Interface() {

--- a/src/core/hle/service/dlp/dlp_fkcl.cpp
+++ b/src/core/hle/service/dlp/dlp_fkcl.cpp
@@ -8,7 +8,23 @@ namespace Service {
 namespace DLP {
 
 const Interface::FunctionInfo FunctionTable[] = {
-    {0x00010083, nullptr, "Initialize"}, {0x000F0000, nullptr, "GetWirelessRebootPassphrase"},
+    {0x00010083, nullptr, "Initialize"},
+    {0x00020000, nullptr, "Finalize"},
+    {0x00030000, nullptr, "GetEventDesc"},
+    {0x00040000, nullptr, "GetChannels"},
+    {0x00050180, nullptr, "StartScan"},
+    {0x00060000, nullptr, "StopScan"},
+    {0x00070080, nullptr, "GetServerInfo"},
+    {0x00080100, nullptr, "GetTitleInfo"},
+    {0x00090040, nullptr, "GetTitleInfoInOrder"},
+    {0x000A0080, nullptr, "DeleteScanInfo"},
+    {0x000B0100, nullptr, "StartFakeSession"},
+    {0x000C0000, nullptr, "GetMyStatus"},
+    {0x000D0040, nullptr, "GetConnectingNodes"},
+    {0x000E0040, nullptr, "GetNodeInfo"},
+    {0x000F0000, nullptr, "GetWirelessRebootPassphrase"},
+    {0x00100000, nullptr, "StopSession"},
+    {0x00110203, nullptr, "Initialize2"},
 };
 
 DLP_FKCL_Interface::DLP_FKCL_Interface() {

--- a/src/core/hle/service/dlp/dlp_srvr.cpp
+++ b/src/core/hle/service/dlp/dlp_srvr.cpp
@@ -11,7 +11,7 @@
 namespace Service {
 namespace DLP {
 
-static void unk_0x000E0040(Interface* self) {
+static void IsChild(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
@@ -24,14 +24,19 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00010183, nullptr, "Initialize"},
     {0x00020000, nullptr, "Finalize"},
     {0x00030000, nullptr, "GetServerState"},
+    {0x00040000, nullptr, "GetEventDescription"},
     {0x00050080, nullptr, "StartAccepting"},
+    {0x00060000, nullptr, "EndAccepting"},
     {0x00070000, nullptr, "StartDistribution"},
     {0x000800C0, nullptr, "SendWirelessRebootPassphrase"},
     {0x00090040, nullptr, "AcceptClient"},
+    {0x000A0040, nullptr, "DisconnectClient"},
     {0x000B0042, nullptr, "GetConnectingClients"},
     {0x000C0040, nullptr, "GetClientInfo"},
     {0x000D0040, nullptr, "GetClientState"},
-    {0x000E0040, unk_0x000E0040, "unk_0x000E0040"},
+    {0x000E0040, IsChild, "IsChild"},
+    {0x000F0303, nullptr, "InitializeWithName"},
+    {0x00100000, nullptr, "GetDupNoticeNeed"},
 };
 
 DLP_SRVR_Interface::DLP_SRVR_Interface() {

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -166,6 +166,15 @@ public:
         return ResultStatus::ErrorNotImplemented;
     }
 
+    /**
+     * Get the title of the application
+     * @param title Reference to store the application title into
+     * @return ResultStatus result of function
+     */
+    virtual ResultStatus ReadTitle(std::string& title) {
+        return ResultStatus::ErrorNotImplemented;
+    }
+
 protected:
     FileUtil::IOFile file;
     bool is_loaded = false;

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -191,22 +191,12 @@ public:
 
     ResultStatus ReadLogo(std::vector<u8>& buffer) override;
 
-    /**
-     * Get the program id of the application
-     * @param out_program_id Reference to store program id into
-     * @return ResultStatus result of function
-     */
     ResultStatus ReadProgramId(u64& out_program_id) override;
 
-    /**
-     * Get the RomFS of the application
-     * @param romfs_file Reference to buffer to store data
-     * @param offset     Offset in the file to the RomFS
-     * @param size       Size of the RomFS in bytes
-     * @return ResultStatus result of function
-     */
     ResultStatus ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
                            u64& size) override;
+
+    ResultStatus ReadTitle(std::string& title) override;
 
 private:
     /**

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -7,6 +7,7 @@
 #include "common/assert.h"
 #include "common/scm_rev.h"
 #include "common/x64/cpu_detect.h"
+#include "core/core.h"
 #include "core/settings.h"
 #include "core/telemetry_session.h"
 
@@ -39,12 +40,19 @@ TelemetrySession::TelemetrySession() {
                             std::chrono::system_clock::now().time_since_epoch())
                             .count()};
     AddField(Telemetry::FieldType::Session, "Init_Time", init_time);
+    std::string program_name;
+    const Loader::ResultStatus res{System::GetInstance().GetAppLoader().ReadTitle(program_name)};
+    if (res == Loader::ResultStatus::Success) {
+        AddField(Telemetry::FieldType::Session, "ProgramName", program_name);
+    }
 
     // Log application information
     const bool is_git_dirty{std::strstr(Common::g_scm_desc, "dirty") != nullptr};
     AddField(Telemetry::FieldType::App, "Git_IsDirty", is_git_dirty);
     AddField(Telemetry::FieldType::App, "Git_Branch", Common::g_scm_branch);
     AddField(Telemetry::FieldType::App, "Git_Revision", Common::g_scm_rev);
+    AddField(Telemetry::FieldType::App, "BuildDate", Common::g_build_date);
+    AddField(Telemetry::FieldType::App, "BuildName", Common::g_build_name);
 
     // Log user system information
     AddField(Telemetry::FieldType::UserSystem, "CPU_Model", Common::GetCPUCaps().cpu_string);
@@ -68,6 +76,15 @@ TelemetrySession::TelemetrySession() {
              Common::GetCPUCaps().sse4_1);
     AddField(Telemetry::FieldType::UserSystem, "CPU_Extension_x64_SSE42",
              Common::GetCPUCaps().sse4_2);
+#ifdef __APPLE__
+    AddField(Telemetry::FieldType::UserSystem, "OsPlatform", "Apple");
+#elif defined(_WIN32)
+    AddField(Telemetry::FieldType::UserSystem, "OsPlatform", "Windows");
+#elif defined(__linux__) || defined(linux) || defined(__linux)
+    AddField(Telemetry::FieldType::UserSystem, "OsPlatform", "Linux");
+#else
+    AddField(Telemetry::FieldType::UserSystem, "OsPlatform", "Unknown");
+#endif
 
     // Log user configuration information
     AddField(Telemetry::FieldType::UserConfig, "Audio_EnableAudioStretching",

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SRCS
             command_processor.cpp
             debug_utils/debug_utils.cpp
+            geometry_pipeline.cpp
             pica.cpp
             primitive_assembly.cpp
             regs.cpp
@@ -29,6 +30,7 @@ set(SRCS
 set(HEADERS
             command_processor.h
             debug_utils/debug_utils.h
+            geometry_pipeline.h
             gpu_debugger.h
             pica.h
             pica_state.h

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SRCS
             shader/shader_interpreter.cpp
             swrasterizer/clipper.cpp
             swrasterizer/framebuffer.cpp
+            swrasterizer/lighting.cpp
             swrasterizer/proctex.cpp
             swrasterizer/rasterizer.cpp
             swrasterizer/swrasterizer.cpp
@@ -55,6 +56,7 @@ set(HEADERS
             shader/shader_interpreter.h
             swrasterizer/clipper.h
             swrasterizer/framebuffer.h
+            swrasterizer/lighting.h
             swrasterizer/proctex.h
             swrasterizer/rasterizer.h
             swrasterizer/swrasterizer.h

--- a/src/video_core/geometry_pipeline.cpp
+++ b/src/video_core/geometry_pipeline.cpp
@@ -1,0 +1,272 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "video_core/geometry_pipeline.h"
+#include "video_core/pica_state.h"
+#include "video_core/regs.h"
+#include "video_core/renderer_base.h"
+#include "video_core/video_core.h"
+
+namespace Pica {
+
+/// An attribute buffering interface for different pipeline modes
+class GeometryPipelineBackend {
+public:
+    /// Checks if there is no incomplete data transfer
+    virtual bool IsEmpty() const = 0;
+
+    /// Checks if the pipeline needs a direct input from index buffer
+    virtual bool NeedIndexInput() const = 0;
+
+    /// Submits an index from index buffer
+    virtual void SubmitIndex(unsigned int val) = 0;
+
+    /**
+     * Submits vertex attributes
+     * @param input attributes of a vertex output from vertex shader
+     * @return if the buffer is full and the geometry shader should be invoked
+     */
+    virtual bool SubmitVertex(const Shader::AttributeBuffer& input) = 0;
+};
+
+// In the Point mode, vertex attributes are sent to the input registers in the geometry shader unit.
+// The size of vertex shader outputs and geometry shader inputs are constants. Geometry shader is
+// invoked upon inputs buffer filled up by vertex shader outputs. For example, if we have a geometry
+// shader that takes 6 inputs, and the vertex shader outputs 2 attributes, it would take 3 vertices
+// for one geometry shader invocation.
+// TODO: what happens when the input size is not divisible by the output size?
+class GeometryPipeline_Point : public GeometryPipelineBackend {
+public:
+    GeometryPipeline_Point(const Regs& regs, Shader::GSUnitState& unit) : regs(regs), unit(unit) {
+        ASSERT(regs.pipeline.variable_primitive == 0);
+        ASSERT(regs.gs.input_to_uniform == 0);
+        vs_output_num = regs.pipeline.vs_outmap_total_minus_1_a + 1;
+        size_t gs_input_num = regs.gs.max_input_attribute_index + 1;
+        ASSERT(gs_input_num % vs_output_num == 0);
+        buffer_cur = attribute_buffer.attr;
+        buffer_end = attribute_buffer.attr + gs_input_num;
+    }
+
+    bool IsEmpty() const override {
+        return buffer_cur == attribute_buffer.attr;
+    }
+
+    bool NeedIndexInput() const override {
+        return false;
+    }
+
+    void SubmitIndex(unsigned int val) override {
+        UNREACHABLE();
+    }
+
+    bool SubmitVertex(const Shader::AttributeBuffer& input) override {
+        buffer_cur = std::copy(input.attr, input.attr + vs_output_num, buffer_cur);
+        if (buffer_cur == buffer_end) {
+            buffer_cur = attribute_buffer.attr;
+            unit.LoadInput(regs.gs, attribute_buffer);
+            return true;
+        }
+        return false;
+    }
+
+private:
+    const Regs& regs;
+    Shader::GSUnitState& unit;
+    Shader::AttributeBuffer attribute_buffer;
+    Math::Vec4<float24>* buffer_cur;
+    Math::Vec4<float24>* buffer_end;
+    unsigned int vs_output_num;
+};
+
+// In VariablePrimitive mode, vertex attributes are buffered into the uniform registers in the
+// geometry shader unit. The number of vertex is variable, which is specified by the first index
+// value in the batch. This mode is usually used for subdivision.
+class GeometryPipeline_VariablePrimitive : public GeometryPipelineBackend {
+public:
+    GeometryPipeline_VariablePrimitive(const Regs& regs, Shader::ShaderSetup& setup)
+        : regs(regs), setup(setup) {
+        ASSERT(regs.pipeline.variable_primitive == 1);
+        ASSERT(regs.gs.input_to_uniform == 1);
+        vs_output_num = regs.pipeline.vs_outmap_total_minus_1_a + 1;
+    }
+
+    bool IsEmpty() const override {
+        return need_index;
+    }
+
+    bool NeedIndexInput() const override {
+        return need_index;
+    }
+
+    void SubmitIndex(unsigned int val) override {
+        DEBUG_ASSERT(need_index);
+
+        // The number of vertex input is put to the uniform register
+        float24 vertex_num = float24::FromFloat32(val);
+        setup.uniforms.f[0] = Math::MakeVec(vertex_num, vertex_num, vertex_num, vertex_num);
+
+        // The second uniform register and so on are used for receiving input vertices
+        buffer_cur = setup.uniforms.f + 1;
+
+        main_vertex_num = regs.pipeline.variable_vertex_main_num_minus_1 + 1;
+        total_vertex_num = val;
+        need_index = false;
+    }
+
+    bool SubmitVertex(const Shader::AttributeBuffer& input) override {
+        DEBUG_ASSERT(!need_index);
+        if (main_vertex_num != 0) {
+            // For main vertices, receive all attributes
+            buffer_cur = std::copy(input.attr, input.attr + vs_output_num, buffer_cur);
+            --main_vertex_num;
+        } else {
+            // For other vertices, only receive the first attribute (usually the position)
+            *(buffer_cur++) = input.attr[0];
+        }
+        --total_vertex_num;
+
+        if (total_vertex_num == 0) {
+            need_index = true;
+            return true;
+        }
+
+        return false;
+    }
+
+private:
+    bool need_index = true;
+    const Regs& regs;
+    Shader::ShaderSetup& setup;
+    unsigned int main_vertex_num;
+    unsigned int total_vertex_num;
+    Math::Vec4<float24>* buffer_cur;
+    unsigned int vs_output_num;
+};
+
+// In FixedPrimitive mode, vertex attributes are buffered into the uniform registers in the geometry
+// shader unit. The number of vertex per shader invocation is constant. This is usually used for
+// particle system.
+class GeometryPipeline_FixedPrimitive : public GeometryPipelineBackend {
+public:
+    GeometryPipeline_FixedPrimitive(const Regs& regs, Shader::ShaderSetup& setup)
+        : regs(regs), setup(setup) {
+        ASSERT(regs.pipeline.variable_primitive == 0);
+        ASSERT(regs.gs.input_to_uniform == 1);
+        vs_output_num = regs.pipeline.vs_outmap_total_minus_1_a + 1;
+        ASSERT(vs_output_num == regs.pipeline.gs_config.stride_minus_1 + 1);
+        size_t vertex_num = regs.pipeline.gs_config.fixed_vertex_num_minus_1 + 1;
+        buffer_cur = buffer_begin = setup.uniforms.f + regs.pipeline.gs_config.start_index;
+        buffer_end = buffer_begin + vs_output_num * vertex_num;
+    }
+
+    bool IsEmpty() const override {
+        return buffer_cur == buffer_begin;
+    }
+
+    bool NeedIndexInput() const override {
+        return false;
+    }
+
+    void SubmitIndex(unsigned int val) override {
+        UNREACHABLE();
+    }
+
+    bool SubmitVertex(const Shader::AttributeBuffer& input) override {
+        buffer_cur = std::copy(input.attr, input.attr + vs_output_num, buffer_cur);
+        if (buffer_cur == buffer_end) {
+            buffer_cur = buffer_begin;
+            return true;
+        }
+        return false;
+    }
+
+private:
+    const Regs& regs;
+    Shader::ShaderSetup& setup;
+    Math::Vec4<float24>* buffer_begin;
+    Math::Vec4<float24>* buffer_cur;
+    Math::Vec4<float24>* buffer_end;
+    unsigned int vs_output_num;
+};
+
+GeometryPipeline::GeometryPipeline(State& state) : state(state) {}
+
+GeometryPipeline::~GeometryPipeline() = default;
+
+void GeometryPipeline::SetVertexHandler(Shader::VertexHandler vertex_handler) {
+    this->vertex_handler = vertex_handler;
+}
+
+void GeometryPipeline::Setup(Shader::ShaderEngine* shader_engine) {
+    if (!backend)
+        return;
+
+    this->shader_engine = shader_engine;
+    shader_engine->SetupBatch(state.gs, state.regs.gs.main_offset);
+}
+
+void GeometryPipeline::Reconfigure() {
+    ASSERT(!backend || backend->IsEmpty());
+
+    if (state.regs.pipeline.use_gs == PipelineRegs::UseGS::No) {
+        backend = nullptr;
+        return;
+    }
+
+    ASSERT(state.regs.pipeline.use_gs == PipelineRegs::UseGS::Yes);
+
+    // The following assumes that when geometry shader is in use, the shader unit 3 is configured as
+    // a geometry shader unit.
+    // TODO: what happens if this is not true?
+    ASSERT(state.regs.pipeline.gs_unit_exclusive_configuration == 1);
+    ASSERT(state.regs.gs.shader_mode == ShaderRegs::ShaderMode::GS);
+
+    state.gs_unit.ConfigOutput(state.regs.gs);
+
+    ASSERT(state.regs.pipeline.vs_outmap_total_minus_1_a ==
+           state.regs.pipeline.vs_outmap_total_minus_1_b);
+
+    switch (state.regs.pipeline.gs_config.mode) {
+    case PipelineRegs::GSMode::Point:
+        backend = std::make_unique<GeometryPipeline_Point>(state.regs, state.gs_unit);
+        break;
+    case PipelineRegs::GSMode::VariablePrimitive:
+        backend = std::make_unique<GeometryPipeline_VariablePrimitive>(state.regs, state.gs);
+        break;
+    case PipelineRegs::GSMode::FixedPrimitive:
+        backend = std::make_unique<GeometryPipeline_FixedPrimitive>(state.regs, state.gs);
+        break;
+    default:
+        UNREACHABLE();
+    }
+}
+
+bool GeometryPipeline::NeedIndexInput() const {
+    if (!backend)
+        return false;
+    return backend->NeedIndexInput();
+}
+
+void GeometryPipeline::SubmitIndex(unsigned int val) {
+    backend->SubmitIndex(val);
+}
+
+void GeometryPipeline::SubmitVertex(const Shader::AttributeBuffer& input) {
+    if (!backend) {
+        // No backend means the geometry shader is disabled, so we send the vertex shader output
+        // directly to the primitive assembler.
+        vertex_handler(input);
+    } else {
+        if (backend->SubmitVertex(input)) {
+            shader_engine->Run(state.gs, state.gs_unit);
+
+            // The uniform b15 is set to true after every geometry shader invocation. This is useful
+            // for the shader to know if this is the first invocation in a batch, if the program set
+            // b15 to false first.
+            state.gs.uniforms.b[15] = true;
+        }
+    }
+}
+
+} // namespace Pica

--- a/src/video_core/geometry_pipeline.h
+++ b/src/video_core/geometry_pipeline.h
@@ -1,0 +1,49 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include "video_core/shader/shader.h"
+
+namespace Pica {
+
+struct State;
+
+class GeometryPipelineBackend;
+
+/// A pipeline receiving from vertex shader and sending to geometry shader and primitive assembler
+class GeometryPipeline {
+public:
+    GeometryPipeline(State& state);
+    ~GeometryPipeline();
+
+    /// Sets the handler for receiving vertex outputs from vertex shader
+    void SetVertexHandler(Shader::VertexHandler vertex_handler);
+
+    /**
+     * Setup the geometry shader unit if it is in use
+     * @param shader_engine the shader engine for the geometry shader to run
+     */
+    void Setup(Shader::ShaderEngine* shader_engine);
+
+    /// Reconfigures the pipeline according to current register settings
+    void Reconfigure();
+
+    /// Checks if the pipeline needs a direct input from index buffer
+    bool NeedIndexInput() const;
+
+    /// Submits an index from index buffer. Call this only when NeedIndexInput returns true
+    void SubmitIndex(unsigned int val);
+
+    /// Submits vertex attributes output from vertex shader
+    void SubmitVertex(const Shader::AttributeBuffer& input);
+
+private:
+    Shader::VertexHandler vertex_handler;
+    Shader::ShaderEngine* shader_engine;
+    std::unique_ptr<GeometryPipelineBackend> backend;
+    State& state;
+};
+} // namespace Pica

--- a/src/video_core/pica.cpp
+++ b/src/video_core/pica.cpp
@@ -3,9 +3,11 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include "video_core/geometry_pipeline.h"
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
-#include "video_core/regs_pipeline.h"
+#include "video_core/renderer_base.h"
+#include "video_core/video_core.h"
 
 namespace Pica {
 
@@ -22,6 +24,23 @@ void Shutdown() {
 template <typename T>
 void Zero(T& o) {
     memset(&o, 0, sizeof(o));
+}
+
+State::State() : geometry_pipeline(*this) {
+    auto SubmitVertex = [this](const Shader::AttributeBuffer& vertex) {
+        using Pica::Shader::OutputVertex;
+        auto AddTriangle = [this](const OutputVertex& v0, const OutputVertex& v1,
+                                  const OutputVertex& v2) {
+            VideoCore::g_renderer->Rasterizer()->AddTriangle(v0, v1, v2);
+        };
+        primitive_assembler.SubmitVertex(
+            Shader::OutputVertex::FromAttributeBuffer(regs.rasterizer, vertex), AddTriangle);
+    };
+
+    auto SetWinding = [this]() { primitive_assembler.SetWinding(); };
+
+    g_state.gs_unit.SetVertexHandler(SubmitVertex, SetWinding);
+    g_state.geometry_pipeline.SetVertexHandler(SubmitVertex);
 }
 
 void State::Reset() {

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -79,7 +79,7 @@ struct State {
         std::array<ColorDifferenceEntry, 256> color_diff_table;
     } proctex;
 
-    struct {
+    struct Lighting {
         union LutEntry {
             // Used for raw access
             u32 raw;

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -8,6 +8,7 @@
 #include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/vector_math.h"
+#include "video_core/geometry_pipeline.h"
 #include "video_core/primitive_assembly.h"
 #include "video_core/regs.h"
 #include "video_core/shader/shader.h"
@@ -16,6 +17,7 @@ namespace Pica {
 
 /// Struct used to describe current Pica state
 struct State {
+    State();
     void Reset();
 
     /// Pica registers
@@ -137,7 +139,16 @@ struct State {
         Shader::AttributeBuffer input_vertex;
         // Index of the next attribute to be loaded into `input_vertex`.
         u32 current_attribute = 0;
+        // Indicates the immediate mode just started and the geometry pipeline needs to reconfigure
+        bool reset_geometry_pipeline = true;
     } immediate;
+
+    // the geometry shader needs to be kept in the global state because some shaders relie on
+    // preserved register value across shader invocation.
+    // TODO: also bring the three vertex shader units here and implement the shader scheduler.
+    Shader::GSUnitState gs_unit;
+
+    GeometryPipeline geometry_pipeline;
 
     // This is constructed with a dummy triangle topology
     PrimitiveAssembler<Shader::OutputVertex> primitive_assembler;

--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -17,15 +17,18 @@ template <typename VertexType>
 void PrimitiveAssembler<VertexType>::SubmitVertex(const VertexType& vtx,
                                                   TriangleHandler triangle_handler) {
     switch (topology) {
-    // TODO: Figure out what's different with TriangleTopology::Shader.
     case PipelineRegs::TriangleTopology::List:
     case PipelineRegs::TriangleTopology::Shader:
         if (buffer_index < 2) {
             buffer[buffer_index++] = vtx;
         } else {
             buffer_index = 0;
-
-            triangle_handler(buffer[0], buffer[1], vtx);
+            if (topology == PipelineRegs::TriangleTopology::Shader && winding) {
+                triangle_handler(buffer[1], buffer[0], vtx);
+                winding = false;
+            } else {
+                triangle_handler(buffer[0], buffer[1], vtx);
+            }
         }
         break;
 
@@ -51,9 +54,15 @@ void PrimitiveAssembler<VertexType>::SubmitVertex(const VertexType& vtx,
 }
 
 template <typename VertexType>
+void PrimitiveAssembler<VertexType>::SetWinding() {
+    winding = true;
+}
+
+template <typename VertexType>
 void PrimitiveAssembler<VertexType>::Reset() {
     buffer_index = 0;
     strip_ready = false;
+    winding = false;
 }
 
 template <typename VertexType>

--- a/src/video_core/primitive_assembly.h
+++ b/src/video_core/primitive_assembly.h
@@ -30,6 +30,12 @@ struct PrimitiveAssembler {
     void SubmitVertex(const VertexType& vtx, TriangleHandler triangle_handler);
 
     /**
+     * Invert the vertex order of the next triangle. Called by geometry shader emitter.
+     * This only takes effect for TriangleTopology::Shader.
+     */
+    void SetWinding();
+
+    /**
      * Resets the internal state of the PrimitiveAssembler.
      */
     void Reset();
@@ -45,6 +51,7 @@ private:
     int buffer_index;
     VertexType buffer[2];
     bool strip_ready = false;
+    bool winding = false;
 };
 
 } // namespace

--- a/src/video_core/regs_pipeline.h
+++ b/src/video_core/regs_pipeline.h
@@ -202,7 +202,14 @@ struct PipelineRegs {
     /// Number of input attributes to the vertex shader minus 1
     BitField<0, 4, u32> max_input_attrib_index;
 
-    INSERT_PADDING_WORDS(2);
+    INSERT_PADDING_WORDS(1);
+
+    // The shader unit 3, which can be used for both vertex and geometry shader, gets its
+    // configuration depending on this register. If this is not set, unit 3 will share some
+    // configuration with other units. It is known that program code and swizzle pattern uploaded
+    // via regs.vs will be also uploaded to unit 3 if this is not set. Although very likely, it is
+    // still unclear whether uniforms and other configuration can be also shared.
+    BitField<0, 1, u32> gs_unit_exclusive_configuration;
 
     enum class GPUMode : u32 {
         Drawing = 0,

--- a/src/video_core/regs_pipeline.h
+++ b/src/video_core/regs_pipeline.h
@@ -147,7 +147,15 @@ struct PipelineRegs {
     // Number of vertices to render
     u32 num_vertices;
 
-    INSERT_PADDING_WORDS(0x1);
+    enum class UseGS : u32 {
+        No = 0,
+        Yes = 2,
+    };
+
+    union {
+        BitField<0, 2, UseGS> use_gs;
+        BitField<31, 1, u32> variable_primitive;
+    };
 
     // The index of the first vertex to render
     u32 vertex_offset;
@@ -218,7 +226,29 @@ struct PipelineRegs {
 
     GPUMode gpu_mode;
 
-    INSERT_PADDING_WORDS(0x18);
+    INSERT_PADDING_WORDS(0x4);
+    BitField<0, 4, u32> vs_outmap_total_minus_1_a;
+    INSERT_PADDING_WORDS(0x6);
+    BitField<0, 4, u32> vs_outmap_total_minus_1_b;
+
+    enum class GSMode : u32 {
+        Point = 0,
+        VariablePrimitive = 1,
+        FixedPrimitive = 2,
+    };
+
+    union {
+        BitField<0, 8, GSMode> mode;
+        BitField<8, 4, u32> fixed_vertex_num_minus_1;
+        BitField<12, 4, u32> stride_minus_1;
+        BitField<16, 4, u32> start_index;
+    } gs_config;
+
+    INSERT_PADDING_WORDS(0x1);
+
+    u32 variable_vertex_main_num_minus_1;
+
+    INSERT_PADDING_WORDS(0x9);
 
     enum class TriangleTopology : u32 {
         List = 0,

--- a/src/video_core/regs_shader.h
+++ b/src/video_core/regs_shader.h
@@ -24,9 +24,16 @@ struct ShaderRegs {
 
     INSERT_PADDING_WORDS(0x4);
 
+    enum ShaderMode {
+        GS = 0x08,
+        VS = 0xA0,
+    };
+
     union {
         // Number of input attributes to shader unit - 1
         BitField<0, 4, u32> max_input_attribute_index;
+        BitField<8, 8, u32> input_to_uniform;
+        BitField<24, 8, ShaderMode> shader_mode;
     };
 
     // Offset to shader program entry point (in words)

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -21,7 +21,8 @@ namespace Pica {
 
 namespace Shader {
 
-OutputVertex OutputVertex::FromAttributeBuffer(const RasterizerRegs& regs, AttributeBuffer& input) {
+OutputVertex OutputVertex::FromAttributeBuffer(const RasterizerRegs& regs,
+                                               const AttributeBuffer& input) {
     // Setup output data
     union {
         OutputVertex ret{};

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -82,6 +82,44 @@ void UnitState::WriteOutput(const ShaderRegs& config, AttributeBuffer& output) {
     }
 }
 
+UnitState::UnitState(GSEmitter* emitter) : emitter_ptr(emitter) {}
+
+GSEmitter::GSEmitter() {
+    handlers = new Handlers;
+}
+
+GSEmitter::~GSEmitter() {
+    delete handlers;
+}
+
+void GSEmitter::Emit(Math::Vec4<float24> (&vertex)[16]) {
+    ASSERT(vertex_id < 3);
+    std::copy(std::begin(vertex), std::end(vertex), buffer[vertex_id].begin());
+    if (prim_emit) {
+        if (winding)
+            handlers->winding_setter();
+        for (unsigned int i = 0; i < 3; ++i) {
+            AttributeBuffer output;
+            unsigned int output_i = 0;
+            for (unsigned int reg : Common::BitSet<u32>(output_mask)) {
+                output.attr[output_i++] = buffer[i][reg];
+            }
+            handlers->vertex_handler(output);
+        }
+    }
+}
+
+GSUnitState::GSUnitState() : UnitState(&emitter) {}
+
+void GSUnitState::SetVertexHandler(VertexHandler vertex_handler, WindingSetter winding_setter) {
+    emitter.handlers->vertex_handler = vertex_handler;
+    emitter.handlers->winding_setter = winding_setter;
+}
+
+void GSUnitState::ConfigOutput(const ShaderRegs& config) {
+    emitter.output_mask = config.output_mask;
+}
+
 MICROPROFILE_DEFINE(GPU_Shader, "GPU", "Shader", MP_RGB(50, 50, 240));
 
 #ifdef ARCHITECTURE_x86_64

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -50,7 +50,8 @@ struct OutputVertex {
     INSERT_PADDING_WORDS(1);
     Math::Vec2<float24> tc2;
 
-    static OutputVertex FromAttributeBuffer(const RasterizerRegs& regs, AttributeBuffer& output);
+    static OutputVertex FromAttributeBuffer(const RasterizerRegs& regs,
+                                            const AttributeBuffer& output);
 };
 #define ASSERT_POS(var, pos)                                                                       \
     static_assert(offsetof(OutputVertex, var) == pos * sizeof(float24), "Semantic at wrong "       \

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstddef>
+#include <functional>
 #include <type_traits>
 #include <nihstro/shader_bytecode.h>
 #include "common/assert.h"
@@ -30,6 +31,12 @@ constexpr unsigned MAX_SWIZZLE_DATA_LENGTH = 4096;
 struct AttributeBuffer {
     alignas(16) Math::Vec4<float24> attr[16];
 };
+
+/// Handler type for receiving vertex outputs from vertex shader or geometry shader
+using VertexHandler = std::function<void(const AttributeBuffer&)>;
+
+/// Handler type for signaling to invert the vertex order of the next triangle
+using WindingSetter = std::function<void()>;
 
 struct OutputVertex {
     Math::Vec4<float24> pos;
@@ -61,12 +68,36 @@ static_assert(std::is_pod<OutputVertex>::value, "Structure is not POD");
 static_assert(sizeof(OutputVertex) == 24 * sizeof(float), "OutputVertex has invalid size");
 
 /**
+ * This structure contains state information for primitive emitting in geometry shader.
+ */
+struct GSEmitter {
+    std::array<std::array<Math::Vec4<float24>, 16>, 3> buffer;
+    u8 vertex_id;
+    bool prim_emit;
+    bool winding;
+    u32 output_mask;
+
+    // Function objects are hidden behind a raw pointer to make the structure standard layout type,
+    // for JIT to use offsetof to access other members.
+    struct Handlers {
+        VertexHandler vertex_handler;
+        WindingSetter winding_setter;
+    } * handlers;
+
+    GSEmitter();
+    ~GSEmitter();
+    void Emit(Math::Vec4<float24> (&vertex)[16]);
+};
+static_assert(std::is_standard_layout<GSEmitter>::value, "GSEmitter is not standard layout type");
+
+/**
  * This structure contains the state information that needs to be unique for a shader unit. The 3DS
  * has four shader units that process shaders in parallel. At the present, Citra only implements a
  * single shader unit that processes all shaders serially. Putting the state information in a struct
  * here will make it easier for us to parallelize the shader processing later.
  */
 struct UnitState {
+    UnitState(GSEmitter* emitter = nullptr);
     struct Registers {
         // The registers are accessed by the shader JIT using SSE instructions, and are therefore
         // required to be 16-byte aligned.
@@ -81,6 +112,8 @@ struct UnitState {
     // Two Address registers and one loop counter
     // TODO: How many bits do these actually have?
     s32 address_registers[3];
+
+    GSEmitter* emitter_ptr;
 
     static size_t InputOffset(const SourceRegister& reg) {
         switch (reg.GetRegisterType()) {
@@ -123,6 +156,18 @@ struct UnitState {
     void LoadInput(const ShaderRegs& config, const AttributeBuffer& input);
 
     void WriteOutput(const ShaderRegs& config, AttributeBuffer& output);
+};
+
+/**
+ * This is an extended shader unit state that represents the special unit that can run both vertex
+ * shader and geometry shader. It contains an additional primitive emitter and utilities for
+ * geometry shader.
+ */
+struct GSUnitState : public UnitState {
+    GSUnitState();
+    GSEmitter emitter;
+    void SetVertexHandler(VertexHandler vertex_handler, WindingSetter winding_setter);
+    void ConfigOutput(const ShaderRegs& config);
 };
 
 struct ShaderSetup {

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -636,6 +636,22 @@ static void RunInterpreter(const ShaderSetup& setup, UnitState& state, DebugData
                 break;
             }
 
+            case OpCode::Id::EMIT: {
+                GSEmitter* emitter = state.emitter_ptr;
+                ASSERT_MSG(emitter, "Execute EMIT on VS");
+                emitter->Emit(state.registers.output);
+                break;
+            }
+
+            case OpCode::Id::SETEMIT: {
+                GSEmitter* emitter = state.emitter_ptr;
+                ASSERT_MSG(emitter, "Execute SETEMIT on VS");
+                emitter->vertex_id = instr.setemit.vertex_id;
+                emitter->prim_emit = instr.setemit.prim_emit != 0;
+                emitter->winding = instr.setemit.winding != 0;
+                break;
+            }
+
             default:
                 LOG_ERROR(HW_GPU, "Unhandled instruction: 0x%02x (%s): 0x%08x",
                           (int)instr.opcode.Value().EffectiveOpCode(),

--- a/src/video_core/shader/shader_jit_x64_compiler.h
+++ b/src/video_core/shader/shader_jit_x64_compiler.h
@@ -66,6 +66,8 @@ public:
     void Compile_JMP(Instruction instr);
     void Compile_CMP(Instruction instr);
     void Compile_MAD(Instruction instr);
+    void Compile_EMIT(Instruction instr);
+    void Compile_SETE(Instruction instr);
 
 private:
     void Compile_Block(unsigned end);

--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -95,6 +95,17 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
     static const size_t MAX_VERTICES = 9;
     static_vector<Vertex, MAX_VERTICES> buffer_a = {v0, v1, v2};
     static_vector<Vertex, MAX_VERTICES> buffer_b;
+
+    auto FlipQuaternionIfOpposite = [](auto& a, const auto& b) {
+        if (Math::Dot(a, b) < float24::Zero())
+            a = -a;
+    };
+
+    // Flip the quaternions if they are opposite to prevent interpolating them over the wrong
+    // direction.
+    FlipQuaternionIfOpposite(buffer_a[1].quat, buffer_a[0].quat);
+    FlipQuaternionIfOpposite(buffer_a[2].quat, buffer_a[0].quat);
+
     auto* output_list = &buffer_a;
     auto* input_list = &buffer_b;
 

--- a/src/video_core/swrasterizer/lighting.cpp
+++ b/src/video_core/swrasterizer/lighting.cpp
@@ -1,0 +1,250 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/math_util.h"
+#include "video_core/swrasterizer/lighting.h"
+
+namespace Pica {
+
+static float LookupLightingLut(const Pica::State::Lighting& lighting, size_t lut_index, u8 index,
+                               float delta) {
+    ASSERT_MSG(lut_index < lighting.luts.size(), "Out of range lut");
+    ASSERT_MSG(index < lighting.luts[lut_index].size(), "Out of range index");
+
+    const auto& lut = lighting.luts[lut_index][index];
+
+    float lut_value = lut.ToFloat();
+    float lut_diff = lut.DiffToFloat();
+
+    return lut_value + lut_diff * delta;
+}
+
+std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
+    const Pica::LightingRegs& lighting, const Pica::State::Lighting& lighting_state,
+    const Math::Quaternion<float>& normquat, const Math::Vec3<float>& view) {
+
+    // TODO(Subv): Bump mapping
+    Math::Vec3<float> surface_normal = {0.0f, 0.0f, 1.0f};
+
+    if (lighting.config0.bump_mode != LightingRegs::LightingBumpMode::None) {
+        LOG_CRITICAL(HW_GPU, "unimplemented bump mapping");
+        UNIMPLEMENTED();
+    }
+
+    // Use the normalized the quaternion when performing the rotation
+    auto normal = Math::QuaternionRotate(normquat, surface_normal);
+
+    Math::Vec4<float> diffuse_sum = {0.0f, 0.0f, 0.0f, 1.0f};
+    Math::Vec4<float> specular_sum = {0.0f, 0.0f, 0.0f, 1.0f};
+
+    for (unsigned light_index = 0; light_index <= lighting.max_light_index; ++light_index) {
+        unsigned num = lighting.light_enable.GetNum(light_index);
+        const auto& light_config = lighting.light[num];
+
+        Math::Vec3<float> refl_value = {};
+        Math::Vec3<float> position = {float16::FromRaw(light_config.x).ToFloat32(),
+                                      float16::FromRaw(light_config.y).ToFloat32(),
+                                      float16::FromRaw(light_config.z).ToFloat32()};
+        Math::Vec3<float> light_vector;
+
+        if (light_config.config.directional)
+            light_vector = position;
+        else
+            light_vector = position + view;
+
+        light_vector.Normalize();
+
+        float dist_atten = 1.0f;
+        if (!lighting.IsDistAttenDisabled(num)) {
+            auto distance = (-view - position).Length();
+            float scale = Pica::float20::FromRaw(light_config.dist_atten_scale).ToFloat32();
+            float bias = Pica::float20::FromRaw(light_config.dist_atten_bias).ToFloat32();
+            size_t lut =
+                static_cast<size_t>(LightingRegs::LightingSampler::DistanceAttenuation) + num;
+
+            float sample_loc = MathUtil::Clamp(scale * distance + bias, 0.0f, 1.0f);
+
+            u8 lutindex =
+                static_cast<u8>(MathUtil::Clamp(std::floor(sample_loc * 256.0f), 0.0f, 255.0f));
+            float delta = sample_loc * 256 - lutindex;
+            dist_atten = LookupLightingLut(lighting_state, lut, lutindex, delta);
+        }
+
+        auto GetLutValue = [&](LightingRegs::LightingLutInput input, bool abs,
+                               LightingRegs::LightingScale scale_enum,
+                               LightingRegs::LightingSampler sampler) {
+            Math::Vec3<float> norm_view = view.Normalized();
+            Math::Vec3<float> half_angle = (norm_view + light_vector).Normalized();
+            float result = 0.0f;
+
+            switch (input) {
+            case LightingRegs::LightingLutInput::NH:
+                result = Math::Dot(normal, half_angle);
+                break;
+
+            case LightingRegs::LightingLutInput::VH:
+                result = Math::Dot(norm_view, half_angle);
+                break;
+
+            case LightingRegs::LightingLutInput::NV:
+                result = Math::Dot(normal, norm_view);
+                break;
+
+            case LightingRegs::LightingLutInput::LN:
+                result = Math::Dot(light_vector, normal);
+                break;
+
+            default:
+                LOG_CRITICAL(HW_GPU, "Unknown lighting LUT input %u\n", static_cast<u32>(input));
+                UNIMPLEMENTED();
+                result = 0.0f;
+            }
+
+            u8 index;
+            float delta;
+
+            if (abs) {
+                if (light_config.config.two_sided_diffuse)
+                    result = std::abs(result);
+                else
+                    result = std::max(result, 0.0f);
+
+                float flr = std::floor(result * 256.0f);
+                index = static_cast<u8>(MathUtil::Clamp(flr, 0.0f, 255.0f));
+                delta = result * 256 - index;
+            } else {
+                float flr = std::floor(result * 128.0f);
+                s8 signed_index = static_cast<s8>(MathUtil::Clamp(flr, -128.0f, 127.0f));
+                delta = result * 128.0f - signed_index;
+                index = static_cast<u8>(signed_index);
+            }
+
+            float scale = lighting.lut_scale.GetScale(scale_enum);
+            return scale *
+                   LookupLightingLut(lighting_state, static_cast<size_t>(sampler), index, delta);
+        };
+
+        // Specular 0 component
+        float d0_lut_value = 1.0f;
+        if (lighting.config1.disable_lut_d0 == 0 &&
+            LightingRegs::IsLightingSamplerSupported(
+                lighting.config0.config, LightingRegs::LightingSampler::Distribution0)) {
+            d0_lut_value =
+                GetLutValue(lighting.lut_input.d0, lighting.abs_lut_input.disable_d0 == 0,
+                            lighting.lut_scale.d0, LightingRegs::LightingSampler::Distribution0);
+        }
+
+        Math::Vec3<float> specular_0 = d0_lut_value * light_config.specular_0.ToVec3f();
+
+        // If enabled, lookup ReflectRed value, otherwise, 1.0 is used
+        if (lighting.config1.disable_lut_rr == 0 &&
+            LightingRegs::IsLightingSamplerSupported(lighting.config0.config,
+                                                     LightingRegs::LightingSampler::ReflectRed)) {
+            refl_value.x =
+                GetLutValue(lighting.lut_input.rr, lighting.abs_lut_input.disable_rr == 0,
+                            lighting.lut_scale.rr, LightingRegs::LightingSampler::ReflectRed);
+        } else {
+            refl_value.x = 1.0f;
+        }
+
+        // If enabled, lookup ReflectGreen value, otherwise, ReflectRed value is used
+        if (lighting.config1.disable_lut_rg == 0 &&
+            LightingRegs::IsLightingSamplerSupported(lighting.config0.config,
+                                                     LightingRegs::LightingSampler::ReflectGreen)) {
+            refl_value.y =
+                GetLutValue(lighting.lut_input.rg, lighting.abs_lut_input.disable_rg == 0,
+                            lighting.lut_scale.rg, LightingRegs::LightingSampler::ReflectGreen);
+        } else {
+            refl_value.y = refl_value.x;
+        }
+
+        // If enabled, lookup ReflectBlue value, otherwise, ReflectRed value is used
+        if (lighting.config1.disable_lut_rb == 0 &&
+            LightingRegs::IsLightingSamplerSupported(lighting.config0.config,
+                                                     LightingRegs::LightingSampler::ReflectBlue)) {
+            refl_value.z =
+                GetLutValue(lighting.lut_input.rb, lighting.abs_lut_input.disable_rb == 0,
+                            lighting.lut_scale.rb, LightingRegs::LightingSampler::ReflectBlue);
+        } else {
+            refl_value.z = refl_value.x;
+        }
+
+        // Specular 1 component
+        float d1_lut_value = 1.0f;
+        if (lighting.config1.disable_lut_d1 == 0 &&
+            LightingRegs::IsLightingSamplerSupported(
+                lighting.config0.config, LightingRegs::LightingSampler::Distribution1)) {
+            d1_lut_value =
+                GetLutValue(lighting.lut_input.d1, lighting.abs_lut_input.disable_d1 == 0,
+                            lighting.lut_scale.d1, LightingRegs::LightingSampler::Distribution1);
+        }
+
+        Math::Vec3<float> specular_1 =
+            d1_lut_value * refl_value * light_config.specular_1.ToVec3f();
+
+        // Fresnel
+        if (lighting.config1.disable_lut_fr == 0 &&
+            LightingRegs::IsLightingSamplerSupported(lighting.config0.config,
+                                                     LightingRegs::LightingSampler::Fresnel)) {
+
+            float lut_value =
+                GetLutValue(lighting.lut_input.fr, lighting.abs_lut_input.disable_fr == 0,
+                            lighting.lut_scale.fr, LightingRegs::LightingSampler::Fresnel);
+
+            // Enabled for diffuse lighting alpha component
+            if (lighting.config0.fresnel_selector ==
+                    LightingRegs::LightingFresnelSelector::PrimaryAlpha ||
+                lighting.config0.fresnel_selector == LightingRegs::LightingFresnelSelector::Both) {
+                diffuse_sum.a() *= lut_value;
+            }
+
+            // Enabled for the specular lighting alpha component
+            if (lighting.config0.fresnel_selector ==
+                    LightingRegs::LightingFresnelSelector::SecondaryAlpha ||
+                lighting.config0.fresnel_selector == LightingRegs::LightingFresnelSelector::Both) {
+                specular_sum.a() *= lut_value;
+            }
+        }
+
+        auto dot_product = Math::Dot(light_vector, normal);
+
+        // Calculate clamp highlights before applying the two-sided diffuse configuration to the dot
+        // product.
+        float clamp_highlights = 1.0f;
+        if (lighting.config0.clamp_highlights) {
+            if (dot_product <= 0.0f)
+                clamp_highlights = 0.0f;
+            else
+                clamp_highlights = 1.0f;
+        }
+
+        if (light_config.config.two_sided_diffuse)
+            dot_product = std::abs(dot_product);
+        else
+            dot_product = std::max(dot_product, 0.0f);
+
+        auto diffuse =
+            light_config.diffuse.ToVec3f() * dot_product + light_config.ambient.ToVec3f();
+        diffuse_sum += Math::MakeVec(diffuse * dist_atten, 0.0f);
+
+        specular_sum +=
+            Math::MakeVec((specular_0 + specular_1) * clamp_highlights * dist_atten, 0.0f);
+    }
+
+    diffuse_sum += Math::MakeVec(lighting.global_ambient.ToVec3f(), 0.0f);
+
+    auto diffuse = Math::MakeVec<float>(MathUtil::Clamp(diffuse_sum.x, 0.0f, 1.0f) * 255,
+                                        MathUtil::Clamp(diffuse_sum.y, 0.0f, 1.0f) * 255,
+                                        MathUtil::Clamp(diffuse_sum.z, 0.0f, 1.0f) * 255,
+                                        MathUtil::Clamp(diffuse_sum.w, 0.0f, 1.0f) * 255)
+                       .Cast<u8>();
+    auto specular = Math::MakeVec<float>(MathUtil::Clamp(specular_sum.x, 0.0f, 1.0f) * 255,
+                                         MathUtil::Clamp(specular_sum.y, 0.0f, 1.0f) * 255,
+                                         MathUtil::Clamp(specular_sum.z, 0.0f, 1.0f) * 255,
+                                         MathUtil::Clamp(specular_sum.w, 0.0f, 1.0f) * 255)
+                        .Cast<u8>();
+    return {diffuse, specular};
+}
+
+} // namespace Pica

--- a/src/video_core/swrasterizer/lighting.h
+++ b/src/video_core/swrasterizer/lighting.h
@@ -1,0 +1,18 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <tuple>
+#include "common/quaternion.h"
+#include "common/vector_math.h"
+#include "video_core/pica_state.h"
+
+namespace Pica {
+
+std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
+    const Pica::LightingRegs& lighting, const Pica::State::Lighting& lighting_state,
+    const Math::Quaternion<float>& normquat, const Math::Vec3<float>& view);
+
+} // namespace Pica


### PR DESCRIPTION
difference from @JayFoxRox original implementation:
 - respect the topology type in assembler even with GS (HW tested), and move winding (inverting) into the specific `Shader` topology type (HW tested)
 - keep the vertex cache, and instead change the cached vertex type. The cache happens before GS
 - wrap the GS input buffer stuff into `GeometryPipeline` and move it to global state, for supporting immediate mode (HW tested) buffering (HW tested) and the other GS mode
 - add support for mode 1 (for subdivision) and 2 (for particle system)

----

Some test result:
 - devkitPro/3ds-examples/graphics/gpu/geoshader: works fine
 - devkitPro/3ds-examples/graphics/gpu/loop_subdivision: works fine
 - devkitPro/3ds-examples/graphics/gpu/particles: works fine
 - Pokemon OR/AS: works fine
 - Monster Hunter XX: works fine
 - Professor Layton and the Miracle Mask: works fine
 - snes9x (a snes emulator): display nothing in game. If all shader registers are initialized to 1, it works fine then. The source code shows that its geometry shader never sets the output position.w. This presumably relies on register preservation for the special GS unit when switching between VS and GS, so this will only work when the 4 shader units and the scheduler is implemented.
 - other games tested by players using bleeding edge build: only one crash from ASSERT found, which is later fixed in this branch


