### PR TITLE
decrypt rom

### DIFF
--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -173,9 +173,9 @@ private:
         if (ncch_data.romfs_file) {
             std::unique_ptr<DelayGenerator> delay_generator =
                 std::make_unique<RomFSDelayGenerator>();
-            return MakeResult<std::unique_ptr<FileBackend>>(
-                std::make_unique<IVFCFile>(ncch_data.romfs_file, ncch_data.romfs_offset,
-                                           ncch_data.romfs_size, std::move(delay_generator)));
+            return MakeResult<std::unique_ptr<FileBackend>>(std::make_unique<IVFCFile>(
+                ncch_data.romfs_file, ncch_data.romfs_offset, ncch_data.romfs_size,
+                std::move(delay_generator), ncch_data.aes_context));
         } else {
             LOG_INFO(Service_FS, "Unable to read RomFS");
             return ERROR_ROMFS_NOT_FOUND;
@@ -258,6 +258,7 @@ void ArchiveFactory_SelfNCCH::Register(Loader::AppLoader& app_loader) {
         app_loader.ReadRomFS(romfs_file_, data.romfs_offset, data.romfs_size)) {
 
         data.romfs_file = std::move(romfs_file_);
+        data.aes_context = app_loader.GetRomFSAesContext();
     }
 
     std::shared_ptr<FileUtil::IOFile> update_romfs_file;

--- a/src/core/file_sys/archive_selfncch.h
+++ b/src/core/file_sys/archive_selfncch.h
@@ -29,6 +29,7 @@ struct NCCHData {
     std::shared_ptr<FileUtil::IOFile> update_romfs_file;
     u64 update_romfs_offset = 0;
     u64 update_romfs_size = 0;
+    boost::optional<Loader::AesContext> aes_context;
 };
 
 /// File system interface to the SelfNCCH archive

--- a/src/core/file_sys/ivfc_archive.h
+++ b/src/core/file_sys/ivfc_archive.h
@@ -13,6 +13,7 @@
 #include "core/file_sys/directory_backend.h"
 #include "core/file_sys/file_backend.h"
 #include "core/hle/result.h"
+#include "core/loader/loader.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // FileSys namespace
@@ -91,7 +92,8 @@ protected:
 class IVFCFile : public FileBackend {
 public:
     IVFCFile(std::shared_ptr<FileUtil::IOFile> file, u64 offset, u64 size,
-             std::unique_ptr<DelayGenerator> delay_generator_);
+             std::unique_ptr<DelayGenerator> delay_generator_,
+             boost::optional<Loader::AesContext> aes_context_ = {});
 
     ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
     ResultVal<size_t> Write(u64 offset, size_t length, bool flush, const u8* buffer) override;
@@ -106,6 +108,7 @@ private:
     std::shared_ptr<FileUtil::IOFile> romfs_file;
     u64 data_offset;
     u64 data_size;
+    boost::optional<Loader::AesContext> aes_context;
 };
 
 class IVFCDirectory : public DirectoryBackend {

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -13,6 +13,7 @@
 #include "common/file_util.h"
 #include "common/swap.h"
 #include "core/core.h"
+#include "core/loader/loader.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// NCCH header (Note: "NCCH" appears to be a publicly unknown acronym)
@@ -162,6 +163,8 @@ static_assert(sizeof(ExHeader_Header) == 0x800, "ExHeader structure size is wron
 
 namespace FileSys {
 
+using namespace Loader;
+
 /**
  * Helper which implements an interface to deal with NCCH containers which can
  * contain ExeFS archives or RomFS archives for games or other applications.
@@ -252,6 +255,10 @@ public:
     NCCH_Header ncch_header;
     ExeFs_Header exefs_header;
     ExHeader_Header exheader_header;
+
+    boost::optional<AesContext> exefs_aes;
+    boost::optional<AesContext> exerfs_code_aes;
+    boost::optional<AesContext> romfs_aes;
 
 private:
     bool has_header = false;

--- a/src/core/hw/aes/key.h
+++ b/src/core/hw/aes/key.h
@@ -12,6 +12,11 @@ namespace HW {
 namespace AES {
 
 enum KeySlotID : size_t {
+    NCCHSec3 = 0x18,
+    NCCHSec4 = 0x1B,
+    NCCH7x = 0x25,
+    NCCH = 0x2C,
+
     // AES Keyslot used to generate the UDS data frame CCMP key.
     UDSDataKey = 0x2D,
     APTWrap = 0x31,

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <initializer_list>
 #include <memory>
 #include <string>
@@ -34,6 +35,10 @@ enum class FileType {
     CIA,
     ELF,
     THREEDSX, // 3DSX
+};
+
+struct AesContext {
+    std::array<u8, 16> key, ctr;
 };
 
 /**
@@ -189,6 +194,10 @@ public:
      */
     virtual ResultStatus ReadTitle(std::string& title) {
         return ResultStatus::ErrorNotImplemented;
+    }
+
+    virtual boost::optional<AesContext> GetRomFSAesContext() {
+        return {};
     }
 
 protected:

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -20,6 +20,7 @@
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/cfg/cfg.h"
 #include "core/hle/service/fs/archive.h"
+#include "core/hw/aes/key.h"
 #include "core/loader/ncch.h"
 #include "core/loader/smdh.h"
 #include "core/memory.h"

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -59,6 +59,10 @@ public:
 
     ResultStatus ReadTitle(std::string& title) override;
 
+    boost::optional<AesContext> GetRomFSAesContext() override {
+        return base_ncch.romfs_aes;
+    }
+
 private:
     /**
      * Loads .code section into memory for booting


### PR DESCRIPTION
This is a quick implementation without a full VFS, as a demonstration of how decryption works. However, it is pre-ncch-refactor and needs to rebase. (:p no, I won't rebase it for you so that you can't include it in your unofficial builds)

Problem:
 - how to support seed crypto?
 - the game list also needs rom decrypted in order to display the icon. However, the key initialization is done by core init. This leads to a hack here where the loader always (re-)initialize the key engine when loading a game.