### PR TITLE
renderer_opengl: refactor shader & program objects and add shader manager for rasterizer

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(video_core STATIC
     renderer_opengl/gl_shader_decompiler.h
     renderer_opengl/gl_shader_gen.cpp
     renderer_opengl/gl_shader_gen.h
+    renderer_opengl/gl_shader_manager.cpp
+    renderer_opengl/gl_shader_manager.h
     renderer_opengl/gl_shader_util.cpp
     renderer_opengl/gl_shader_util.h
     renderer_opengl/gl_state.cpp

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -178,6 +178,9 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     glActiveTexture(TextureUnits::ProcTexDiffLUT.Enum());
     glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA32F, proctex_diff_lut_buffer.handle);
 
+    shader_program_manager =
+        std::make_unique<ShaderProgramManager>(GLAD_GL_ARB_separate_shader_objects);
+
     glEnable(GL_BLEND);
 
     SyncEntireState();
@@ -484,6 +487,11 @@ void RasterizerOpenGL::DrawTriangles() {
     state.scissor.y = draw_rect.bottom;
     state.scissor.width = draw_rect.GetWidth();
     state.scissor.height = draw_rect.GetHeight();
+    state.Apply();
+
+    shader_program_manager->UseTrivialVertexShader();
+    shader_program_manager->UseTrivialGeometryShader();
+    shader_program_manager->ApplyTo(state);
     state.Apply();
 
     // Draw the vertex batch
@@ -1253,95 +1261,7 @@ void RasterizerOpenGL::SamplerInfo::SyncWithConfig(
 
 void RasterizerOpenGL::SetShader() {
     auto config = GLShader::PicaShaderConfig::BuildFromRegs(Pica::g_state.regs);
-    std::unique_ptr<PicaShader> shader = std::make_unique<PicaShader>();
-
-    // Find (or generate) the GLSL shader for the current TEV state
-    auto cached_shader = shader_cache.find(config);
-    if (cached_shader != shader_cache.end()) {
-        current_shader = cached_shader->second.get();
-
-        state.draw.shader_program = current_shader->shader.handle;
-        state.Apply();
-    } else {
-        LOG_DEBUG(Render_OpenGL, "Creating new shader");
-
-        shader->shader.Create(GLShader::GenerateVertexShader().c_str(),
-                              GLShader::GenerateFragmentShader(config).c_str());
-
-        state.draw.shader_program = shader->shader.handle;
-        state.Apply();
-
-        // Set the texture samplers to correspond to different texture units
-        GLint uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[0]");
-        if (uniform_tex != -1) {
-            glUniform1i(uniform_tex, TextureUnits::PicaTexture(0).id);
-        }
-        uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[1]");
-        if (uniform_tex != -1) {
-            glUniform1i(uniform_tex, TextureUnits::PicaTexture(1).id);
-        }
-        uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[2]");
-        if (uniform_tex != -1) {
-            glUniform1i(uniform_tex, TextureUnits::PicaTexture(2).id);
-        }
-        uniform_tex = glGetUniformLocation(shader->shader.handle, "tex_cube");
-        if (uniform_tex != -1) {
-            glUniform1i(uniform_tex, TextureUnits::TextureCube.id);
-        }
-
-        // Set the texture samplers to correspond to different lookup table texture units
-        GLint uniform_lut = glGetUniformLocation(shader->shader.handle, "lighting_lut");
-        if (uniform_lut != -1) {
-            glUniform1i(uniform_lut, TextureUnits::LightingLUT.id);
-        }
-
-        GLint uniform_fog_lut = glGetUniformLocation(shader->shader.handle, "fog_lut");
-        if (uniform_fog_lut != -1) {
-            glUniform1i(uniform_fog_lut, TextureUnits::FogLUT.id);
-        }
-
-        GLint uniform_proctex_noise_lut =
-            glGetUniformLocation(shader->shader.handle, "proctex_noise_lut");
-        if (uniform_proctex_noise_lut != -1) {
-            glUniform1i(uniform_proctex_noise_lut, TextureUnits::ProcTexNoiseLUT.id);
-        }
-
-        GLint uniform_proctex_color_map =
-            glGetUniformLocation(shader->shader.handle, "proctex_color_map");
-        if (uniform_proctex_color_map != -1) {
-            glUniform1i(uniform_proctex_color_map, TextureUnits::ProcTexColorMap.id);
-        }
-
-        GLint uniform_proctex_alpha_map =
-            glGetUniformLocation(shader->shader.handle, "proctex_alpha_map");
-        if (uniform_proctex_alpha_map != -1) {
-            glUniform1i(uniform_proctex_alpha_map, TextureUnits::ProcTexAlphaMap.id);
-        }
-
-        GLint uniform_proctex_lut = glGetUniformLocation(shader->shader.handle, "proctex_lut");
-        if (uniform_proctex_lut != -1) {
-            glUniform1i(uniform_proctex_lut, TextureUnits::ProcTexLUT.id);
-        }
-
-        GLint uniform_proctex_diff_lut =
-            glGetUniformLocation(shader->shader.handle, "proctex_diff_lut");
-        if (uniform_proctex_diff_lut != -1) {
-            glUniform1i(uniform_proctex_diff_lut, TextureUnits::ProcTexDiffLUT.id);
-        }
-
-        current_shader = shader_cache.emplace(config, std::move(shader)).first->second.get();
-
-        GLuint block_index = glGetUniformBlockIndex(current_shader->shader.handle, "shader_data");
-        if (block_index != GL_INVALID_INDEX) {
-            GLint block_size;
-            glGetActiveUniformBlockiv(current_shader->shader.handle, block_index,
-                                      GL_UNIFORM_BLOCK_DATA_SIZE, &block_size);
-            ASSERT_MSG(block_size == sizeof(UniformData),
-                       "Uniform block size did not match! Got {}, expected {}",
-                       static_cast<int>(block_size), sizeof(UniformData));
-            glUniformBlockBinding(current_shader->shader.handle, block_index, 0);
-        }
-    }
+    shader_program_manager->UseFragmentShader(config);
 }
 
 void RasterizerOpenGL::SyncClipEnabled() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -8,12 +8,10 @@
 #include <cstddef>
 #include <cstring>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 #include <glad/glad.h>
 #include "common/bit_field.h"
 #include "common/common_types.h"
-#include "common/hash.h"
 #include "common/vector_math.h"
 #include "core/hw/gpu.h"
 #include "video_core/pica_state.h"
@@ -25,13 +23,14 @@
 #include "video_core/regs_texturing.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
-#include "video_core/renderer_opengl/gl_shader_gen.h"
+#include "video_core/renderer_opengl/gl_shader_manager.h"
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/gl_stream_buffer.h"
 #include "video_core/renderer_opengl/pica_to_gl.h"
 #include "video_core/shader/shader.h"
 
 struct ScreenInfo;
+class ShaderProgramManager;
 
 class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:
@@ -51,12 +50,6 @@ public:
     bool AccelerateFill(const GPU::Regs::MemoryFillConfig& config) override;
     bool AccelerateDisplay(const GPU::Regs::FramebufferConfig& config, PAddr framebuffer_addr,
                            u32 pixel_stride, ScreenInfo& screen_info) override;
-
-    /// OpenGL shader generated for a given Pica register state
-    struct PicaShader {
-        /// OpenGL shader resource
-        OGLShader shader;
-    };
 
 private:
     struct SamplerInfo {
@@ -120,47 +113,6 @@ private:
         GLfloat normquat[4];
         GLfloat view[3];
     };
-
-    struct LightSrc {
-        alignas(16) GLvec3 specular_0;
-        alignas(16) GLvec3 specular_1;
-        alignas(16) GLvec3 diffuse;
-        alignas(16) GLvec3 ambient;
-        alignas(16) GLvec3 position;
-        alignas(16) GLvec3 spot_direction; // negated
-        GLfloat dist_atten_bias;
-        GLfloat dist_atten_scale;
-    };
-
-    /// Uniform structure for the Uniform Buffer Object, all vectors must be 16-byte aligned
-    // NOTE: Always keep a vec4 at the end. The GL spec is not clear wether the alignment at
-    //       the end of a uniform block is included in UNIFORM_BLOCK_DATA_SIZE or not.
-    //       Not following that rule will cause problems on some AMD drivers.
-    struct UniformData {
-        GLint framebuffer_scale;
-        GLint alphatest_ref;
-        GLfloat depth_scale;
-        GLfloat depth_offset;
-        GLint scissor_x1;
-        GLint scissor_y1;
-        GLint scissor_x2;
-        GLint scissor_y2;
-        alignas(16) GLvec3 fog_color;
-        alignas(8) GLvec2 proctex_noise_f;
-        alignas(8) GLvec2 proctex_noise_a;
-        alignas(8) GLvec2 proctex_noise_p;
-        alignas(16) GLvec3 lighting_global_ambient;
-        LightSrc light_src[8];
-        alignas(16) GLvec4 const_color[6]; // A vec4 color for each of the six tev stages
-        alignas(16) GLvec4 tev_combiner_buffer_color;
-        alignas(16) GLvec4 clip_coef;
-    };
-
-    static_assert(
-        sizeof(UniformData) == 0x460,
-        "The size of the UniformData structure has changed, update the structure in the shader");
-    static_assert(sizeof(UniformData) < 16384,
-                  "UniformData structure must be less than 16kb as per the OpenGL spec");
 
     /// Syncs entire status to match PICA registers
     void SyncEntireState();
@@ -269,8 +221,6 @@ private:
 
     std::vector<HardwareVertex> vertex_batch;
 
-    std::unordered_map<GLShader::PicaShaderConfig, std::unique_ptr<PicaShader>> shader_cache;
-    const PicaShader* current_shader = nullptr;
     bool shader_dirty;
 
     struct {
@@ -284,6 +234,8 @@ private:
         bool proctex_diff_lut_dirty;
         bool dirty;
     } uniform_block_data = {};
+
+    std::unique_ptr<ShaderProgramManager> shader_program_manager;
 
     std::array<SamplerInfo, 3> texture_samplers;
     OGLVertexArray vertex_array;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -377,7 +377,7 @@ private:
     OGLVertexArray attributeless_vao;
     OGLBuffer d24s8_abgr_buffer;
     GLsizeiptr d24s8_abgr_buffer_size;
-    OGLShader d24s8_abgr_shader;
+    OGLProgram d24s8_abgr_shader;
     GLint d24s8_abgr_tbo_size_u_id;
     GLint d24s8_abgr_viewport_u_id;
 };

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -158,6 +158,37 @@ public:
     GLuint handle = 0;
 };
 
+class OGLPipeline : private NonCopyable {
+public:
+    OGLPipeline() = default;
+    OGLPipeline(OGLPipeline&& o) {
+        handle = std::exchange<GLuint>(o.handle, 0);
+    }
+    ~OGLPipeline() {
+        Release();
+    }
+    OGLPipeline& operator=(OGLPipeline&& o) {
+        handle = std::exchange<GLuint>(o.handle, 0);
+        return *this;
+    }
+
+    void Create() {
+        if (handle != 0)
+            return;
+        glGenProgramPipelines(1, &handle);
+    }
+
+    void Release() {
+        if (handle == 0)
+            return;
+        glDeleteProgramPipelines(1, &handle);
+        OpenGLState::GetCurState().ResetPipeline(handle).Apply();
+        handle = 0;
+    }
+
+    GLuint handle = 0;
+};
+
 class OGLBuffer : private NonCopyable {
 public:
     OGLBuffer() = default;

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -61,6 +61,37 @@ layout (std140) uniform shader_data {
 };
 )";
 
+static std::string GetVertexInterfaceDeclaration(bool is_output, bool separable_shader) {
+    std::string out;
+
+    auto append_variable = [&](const char* var, int location) {
+        if (separable_shader) {
+            out += "layout (location=" + std::to_string(location) + ") ";
+        }
+        out += std::string(is_output ? "out " : "in ") + var + ";\n";
+    };
+
+    append_variable("vec4 primary_color", ATTRIBUTE_COLOR);
+    append_variable("vec2 texcoord0", ATTRIBUTE_TEXCOORD0);
+    append_variable("vec2 texcoord1", ATTRIBUTE_TEXCOORD1);
+    append_variable("vec2 texcoord2", ATTRIBUTE_TEXCOORD2);
+    append_variable("float texcoord0_w", ATTRIBUTE_TEXCOORD0_W);
+    append_variable("vec4 normquat", ATTRIBUTE_NORMQUAT);
+    append_variable("vec3 view", ATTRIBUTE_VIEW);
+
+    if (is_output && separable_shader) {
+        // gl_PerVertex redeclaration is required for separate shader object
+        out += R"(
+out gl_PerVertex {
+    vec4 gl_Position;
+    float gl_ClipDistance[2];
+};
+)";
+    }
+
+    return out;
+}
+
 PicaShaderConfig PicaShaderConfig::BuildFromRegs(const Pica::Regs& regs) {
     PicaShaderConfig res;
 
@@ -197,24 +228,24 @@ static std::string SampleTexture(const PicaShaderConfig& config, unsigned textur
         // Only unit 0 respects the texturing type
         switch (state.texture0_type) {
         case TexturingRegs::TextureConfig::Texture2D:
-            return "texture(tex[0], texcoord[0])";
+            return "texture(tex0, texcoord0)";
         case TexturingRegs::TextureConfig::Projection2D:
-            return "textureProj(tex[0], vec3(texcoord[0], texcoord0_w))";
+            return "textureProj(tex0, vec3(texcoord0, texcoord0_w))";
         case TexturingRegs::TextureConfig::TextureCube:
-            return "texture(tex_cube, vec3(texcoord[0], texcoord0_w))";
+            return "texture(tex_cube, vec3(texcoord0, texcoord0_w))";
         default:
             LOG_CRITICAL(HW_GPU, "Unhandled texture type %x",
                          static_cast<int>(state.texture0_type));
             UNIMPLEMENTED();
-            return "texture(tex[0], texcoord[0])";
+            return "texture(tex0, texcoord0)";
         }
     case 1:
-        return "texture(tex[1], texcoord[1])";
+        return "texture(tex1, texcoord1)";
     case 2:
         if (state.texture2_use_coord1)
-            return "texture(tex[2], texcoord[1])";
+            return "texture(tex2, texcoord1)";
         else
-            return "texture(tex[2], texcoord[2])";
+            return "texture(tex2, texcoord2)";
     case 3:
         if (state.proctex.enable) {
             return "ProcTex()";
@@ -981,7 +1012,12 @@ float ProcTexNoiseCoef(vec2 x) {
     }
 
     out += "vec4 ProcTex() {\n";
-    out += "vec2 uv = abs(texcoord[" + std::to_string(config.state.proctex.coord) + "]);\n";
+    if (config.state.proctex.coord < 3) {
+        out += "vec2 uv = abs(texcoord" + std::to_string(config.state.proctex.coord) + ");\n";
+    } else {
+        NGLOG_CRITICAL(Render_OpenGL, "Unexpected proctex.coord >= 3");
+        out += "vec2 uv = abs(texcoord0);\n";
+    }
 
     // Get shift offset before noise generation
     out += "float u_shift = ";
@@ -1046,23 +1082,24 @@ float ProcTexNoiseCoef(vec2 x) {
     }
 }
 
-std::string GenerateFragmentShader(const PicaShaderConfig& config) {
+std::string GenerateFragmentShader(const PicaShaderConfig& config, bool separable_shader) {
     const auto& state = config.state;
 
-    std::string out = R"(
-#version 330 core
+    std::string out = "#version 330 core\n";
+    if (separable_shader) {
+        out += "#extension GL_ARB_separate_shader_objects : enable\n";
+    }
 
-in vec4 primary_color;
-in vec2 texcoord[3];
-in float texcoord0_w;
-in vec4 normquat;
-in vec3 view;
+    out += GetVertexInterfaceDeclaration(false, separable_shader);
 
+    out += R"(
 in vec4 gl_FragCoord;
 
 out vec4 color;
 
-uniform sampler2D tex[3];
+uniform sampler2D tex0;
+uniform sampler2D tex1;
+uniform sampler2D tex2;
 uniform samplerCube tex_cube;
 uniform samplerBuffer lighting_lut;
 uniform samplerBuffer fog_lut;
@@ -1190,8 +1227,11 @@ vec4 secondary_fragment_color = vec4(0.0);
     return out;
 }
 
-std::string GenerateVertexShader() {
+std::string GenerateTrivialVertexShader(bool separable_shader) {
     std::string out = "#version 330 core\n";
+    if (separable_shader) {
+        out += "#extension GL_ARB_separate_shader_objects : enable\n";
+    }
 
     out += "layout(location = " + std::to_string((int)ATTRIBUTE_POSITION) +
            ") in vec4 vert_position;\n";
@@ -1208,14 +1248,7 @@ std::string GenerateVertexShader() {
            ") in vec4 vert_normquat;\n";
     out += "layout(location = " + std::to_string((int)ATTRIBUTE_VIEW) + ") in vec3 vert_view;\n";
 
-    out += R"(
-out vec4 primary_color;
-out vec2 texcoord[3];
-out float texcoord0_w;
-out vec4 normquat;
-out vec3 view;
-
-)";
+    out += GetVertexInterfaceDeclaration(true, separable_shader);
 
     out += UniformBlockDef;
 
@@ -1223,9 +1256,9 @@ out vec3 view;
 
 void main() {
     primary_color = vert_color;
-    texcoord[0] = vert_texcoord0;
-    texcoord[1] = vert_texcoord1;
-    texcoord[2] = vert_texcoord2;
+    texcoord0 = vert_texcoord0;
+    texcoord1 = vert_texcoord1;
+    texcoord2 = vert_texcoord2;
     texcoord0_w = vert_texcoord0_w;
     normquat = vert_normquat;
     view = vert_view;

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -9,7 +9,9 @@
 #include <functional>
 #include <string>
 #include <type_traits>
+#include "common/hash.h"
 #include "video_core/regs.h"
+#include "video_core/shader/shader.h"
 
 namespace GLShader {
 
@@ -123,18 +125,21 @@ struct PicaShaderConfig : Common::HashableStruct<PicaShaderConfigState> {
 };
 
 /**
- * Generates the GLSL vertex shader program source code for the current Pica state
+ * Generates the GLSL vertex shader program source code that accepts vertices from software shader
+ * and directly passes them to the fragment shader.
+ * @param separable_shader generates shader that can be used for separate shader object
  * @returns String of the shader source code
  */
-std::string GenerateVertexShader();
+std::string GenerateTrivialVertexShader(bool separable_shader);
 
 /**
  * Generates the GLSL fragment shader program source code for the current Pica state
  * @param config ShaderCacheKey object generated for the current Pica state, used for the shader
  *               configuration (NOTE: Use state in this struct only, not the Pica registers!)
+ * @param separable_shader generates shader that can be used for separate shader object
  * @returns String of the shader source code
  */
-std::string GenerateFragmentShader(const PicaShaderConfig& config);
+std::string GenerateFragmentShader(const PicaShaderConfig& config, bool separable_shader);
 
 } // namespace GLShader
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -1,0 +1,208 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <unordered_map>
+#include <boost/functional/hash.hpp>
+#include <boost/variant.hpp>
+#include "video_core/renderer_opengl/gl_shader_manager.h"
+
+static void SetShaderUniformBlockBinding(GLuint shader, const char* name, UniformBindings binding,
+                                         size_t expected_size) {
+    GLuint ub_index = glGetUniformBlockIndex(shader, name);
+    if (ub_index != GL_INVALID_INDEX) {
+        GLint ub_size = 0;
+        glGetActiveUniformBlockiv(shader, ub_index, GL_UNIFORM_BLOCK_DATA_SIZE, &ub_size);
+        ASSERT_MSG(ub_size == expected_size,
+                   "Uniform block size did not match! Got %d, expected %zu",
+                   static_cast<int>(ub_size), expected_size);
+        glUniformBlockBinding(shader, ub_index, static_cast<GLuint>(binding));
+    }
+}
+
+static void SetShaderUniformBlockBindings(GLuint shader) {
+    SetShaderUniformBlockBinding(shader, "shader_data", UniformBindings::Common,
+                                 sizeof(UniformData));
+}
+
+static void SetShaderSamplerBinding(GLuint shader, const char* name,
+                                    TextureUnits::TextureUnit binding) {
+    GLint uniform_tex = glGetUniformLocation(shader, name);
+    if (uniform_tex != -1) {
+        glUniform1i(uniform_tex, binding.id);
+    }
+}
+
+static void SetShaderSamplerBindings(GLuint shader) {
+    OpenGLState cur_state = OpenGLState::GetCurState();
+    GLuint old_program = std::exchange(cur_state.draw.shader_program, shader);
+    cur_state.Apply();
+
+    // Set the texture samplers to correspond to different texture units
+    SetShaderSamplerBinding(shader, "tex0", TextureUnits::PicaTexture(0));
+    SetShaderSamplerBinding(shader, "tex1", TextureUnits::PicaTexture(1));
+    SetShaderSamplerBinding(shader, "tex2", TextureUnits::PicaTexture(2));
+    SetShaderSamplerBinding(shader, "tex_cube", TextureUnits::TextureCube);
+
+    // Set the texture samplers to correspond to different lookup table texture units
+    SetShaderSamplerBinding(shader, "lighting_lut", TextureUnits::LightingLUT);
+    SetShaderSamplerBinding(shader, "fog_lut", TextureUnits::FogLUT);
+    SetShaderSamplerBinding(shader, "proctex_noise_lut", TextureUnits::ProcTexNoiseLUT);
+    SetShaderSamplerBinding(shader, "proctex_color_map", TextureUnits::ProcTexColorMap);
+    SetShaderSamplerBinding(shader, "proctex_alpha_map", TextureUnits::ProcTexAlphaMap);
+    SetShaderSamplerBinding(shader, "proctex_lut", TextureUnits::ProcTexLUT);
+    SetShaderSamplerBinding(shader, "proctex_diff_lut", TextureUnits::ProcTexDiffLUT);
+
+    cur_state.draw.shader_program = old_program;
+    cur_state.Apply();
+}
+
+/**
+ * An object representing a shader program staging. It can be either a shader object or a program
+ * object, depending on whether separable program is used.
+ */
+class OGLShaderStage {
+public:
+    OGLShaderStage(bool separable) {
+        if (separable) {
+            shader_or_program = OGLProgram();
+        } else {
+            shader_or_program = OGLShader();
+        }
+    }
+
+    void Create(const char* source, GLenum type) {
+        if (shader_or_program.which() == 0) {
+            boost::get<OGLShader>(shader_or_program).Create(source, type);
+        } else {
+            OGLShader shader;
+            shader.Create(source, type);
+            OGLProgram& program = boost::get<OGLProgram>(shader_or_program);
+            program.Create(true, {shader.handle});
+            SetShaderUniformBlockBindings(program.handle);
+            SetShaderSamplerBindings(program.handle);
+        }
+    }
+
+    GLuint GetHandle() const {
+        if (shader_or_program.which() == 0) {
+            return boost::get<OGLShader>(shader_or_program).handle;
+        } else {
+            return boost::get<OGLProgram>(shader_or_program).handle;
+        }
+    }
+
+private:
+    boost::variant<OGLShader, OGLProgram> shader_or_program;
+};
+
+class TrivialVertexShader {
+public:
+    TrivialVertexShader(bool separable) : program(separable) {
+        program.Create(GLShader::GenerateTrivialVertexShader(separable).c_str(), GL_VERTEX_SHADER);
+    }
+    GLuint Get() {
+        return program.GetHandle();
+    }
+
+private:
+    OGLShaderStage program;
+};
+
+template <typename KeyConfigType, std::string (*CodeGenerator)(const KeyConfigType&, bool),
+          GLenum ShaderType>
+class ShaderCache {
+public:
+    ShaderCache(bool separable) : separable(separable) {}
+    GLuint Get(const KeyConfigType& config) {
+        auto [iter, new_shader] = shaders.emplace(config, OGLShaderStage{separable});
+        OGLShaderStage& cached_shader = iter->second;
+        if (new_shader) {
+            cached_shader.Create(CodeGenerator(config, separable).c_str(), ShaderType);
+        }
+        return cached_shader.GetHandle();
+    }
+
+private:
+    bool separable;
+    std::unordered_map<KeyConfigType, OGLShaderStage> shaders;
+};
+
+using FragmentShaders =
+    ShaderCache<GLShader::PicaShaderConfig, &GLShader::GenerateFragmentShader, GL_FRAGMENT_SHADER>;
+
+class ShaderProgramManager::Impl {
+public:
+    Impl(bool separable)
+        : separable(separable), trivial_vertex_shader(separable), fragment_shaders(separable) {
+        if (separable)
+            pipeline.Create();
+    }
+
+    struct ShaderTuple {
+        GLuint vs = 0, gs = 0, fs = 0;
+        bool operator==(const ShaderTuple& rhs) const {
+            return std::tie(vs, gs, fs) == std::tie(rhs.vs, rhs.gs, rhs.fs);
+        }
+        struct Hash {
+            std::size_t operator()(const ShaderTuple& tuple) const {
+                std::size_t hash = 0;
+                boost::hash_combine(hash, tuple.vs);
+                boost::hash_combine(hash, tuple.gs);
+                boost::hash_combine(hash, tuple.fs);
+                return hash;
+            }
+        };
+    };
+
+    ShaderTuple current;
+
+    TrivialVertexShader trivial_vertex_shader;
+
+    FragmentShaders fragment_shaders;
+
+    bool separable;
+    std::unordered_map<ShaderTuple, OGLProgram, ShaderTuple::Hash> program_cache;
+    OGLPipeline pipeline;
+};
+
+ShaderProgramManager::ShaderProgramManager(bool separable)
+    : impl(std::make_unique<Impl>(separable)) {}
+
+ShaderProgramManager::~ShaderProgramManager() = default;
+
+void ShaderProgramManager::UseTrivialVertexShader() {
+    impl->current.vs = impl->trivial_vertex_shader.Get();
+}
+
+void ShaderProgramManager::UseTrivialGeometryShader() {
+    impl->current.gs = 0;
+}
+
+void ShaderProgramManager::UseFragmentShader(const GLShader::PicaShaderConfig& config) {
+    impl->current.fs = impl->fragment_shaders.Get(config);
+}
+
+void ShaderProgramManager::ApplyTo(OpenGLState& state) {
+    if (impl->separable) {
+        // Without this reseting, AMD sometimes freezes when one stage is changed but not for the
+        // others
+        glUseProgramStages(impl->pipeline.handle,
+                           GL_VERTEX_SHADER_BIT | GL_GEOMETRY_SHADER_BIT | GL_FRAGMENT_SHADER_BIT,
+                           0);
+
+        glUseProgramStages(impl->pipeline.handle, GL_VERTEX_SHADER_BIT, impl->current.vs);
+        glUseProgramStages(impl->pipeline.handle, GL_GEOMETRY_SHADER_BIT, impl->current.gs);
+        glUseProgramStages(impl->pipeline.handle, GL_FRAGMENT_SHADER_BIT, impl->current.fs);
+        state.draw.shader_program = 0;
+        state.draw.program_pipeline = impl->pipeline.handle;
+    } else {
+        OGLProgram& cached_program = impl->program_cache[impl->current];
+        if (cached_program.handle == 0) {
+            cached_program.Create(false, {impl->current.vs, impl->current.gs, impl->current.fs});
+            SetShaderUniformBlockBindings(cached_program.handle);
+            SetShaderSamplerBindings(cached_program.handle);
+        }
+        state.draw.shader_program = cached_program.handle;
+    }
+}

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -1,0 +1,73 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <glad/glad.h>
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_shader_gen.h"
+#include "video_core/renderer_opengl/pica_to_gl.h"
+
+enum class UniformBindings : GLuint { Common };
+
+struct LightSrc {
+    alignas(16) GLvec3 specular_0;
+    alignas(16) GLvec3 specular_1;
+    alignas(16) GLvec3 diffuse;
+    alignas(16) GLvec3 ambient;
+    alignas(16) GLvec3 position;
+    alignas(16) GLvec3 spot_direction; // negated
+    GLfloat dist_atten_bias;
+    GLfloat dist_atten_scale;
+};
+
+/// Uniform structure for the Uniform Buffer Object, all vectors must be 16-byte aligned
+// NOTE: Always keep a vec4 at the end. The GL spec is not clear wether the alignment at
+//       the end of a uniform block is included in UNIFORM_BLOCK_DATA_SIZE or not.
+//       Not following that rule will cause problems on some AMD drivers.
+struct UniformData {
+    GLint framebuffer_scale;
+    GLint alphatest_ref;
+    GLfloat depth_scale;
+    GLfloat depth_offset;
+    GLint scissor_x1;
+    GLint scissor_y1;
+    GLint scissor_x2;
+    GLint scissor_y2;
+    alignas(16) GLvec3 fog_color;
+    alignas(8) GLvec2 proctex_noise_f;
+    alignas(8) GLvec2 proctex_noise_a;
+    alignas(8) GLvec2 proctex_noise_p;
+    alignas(16) GLvec3 lighting_global_ambient;
+    LightSrc light_src[8];
+    alignas(16) GLvec4 const_color[6]; // A vec4 color for each of the six tev stages
+    alignas(16) GLvec4 tev_combiner_buffer_color;
+    alignas(16) GLvec4 clip_coef;
+};
+
+static_assert(
+    sizeof(UniformData) == 0x460,
+    "The size of the UniformData structure has changed, update the structure in the shader");
+static_assert(sizeof(UniformData) < 16384,
+              "UniformData structure must be less than 16kb as per the OpenGL spec");
+
+/// A class that manage different shader stages and configures them with given config data.
+class ShaderProgramManager {
+public:
+    ShaderProgramManager(bool separable);
+    ~ShaderProgramManager();
+
+    void UseTrivialVertexShader();
+
+    void UseTrivialGeometryShader();
+
+    void UseFragmentShader(const GLShader::PicaShaderConfig& config);
+
+    void ApplyTo(OpenGLState& state);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl;
+};

--- a/src/video_core/renderer_opengl/gl_shader_util.h
+++ b/src/video_core/renderer_opengl/gl_shader_util.h
@@ -4,16 +4,24 @@
 
 #pragma once
 
+#include <vector>
 #include <glad/glad.h>
 
 namespace GLShader {
 
 /**
- * Utility function to create and compile an OpenGL GLSL shader program (vertex + fragment shader)
- * @param vertex_shader String of the GLSL vertex shader program
- * @param fragment_shader String of the GLSL fragment shader program
- * @returns Handle of the newly created OpenGL shader object
+ * Utility function to create and compile an OpenGL GLSL shader
+ * @param source String of the GLSL shader program
+ * @param type Type of the shader (GL_VERTEX_SHADER, GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER)
  */
-GLuint LoadProgram(const char* vertex_shader, const char* fragment_shader);
+GLuint LoadShader(const char* source, GLenum type);
+
+/**
+ * Utility function to create and link an OpenGL GLSL shader program
+ * @param separable_program whether to create a separable program
+ * @param shaders ID of shaders to attach to the program
+ * @returns Handle of the newly created OpenGL program object
+ */
+GLuint LoadProgram(bool separable_program, const std::vector<GLuint>& shaders);
 
 } // namespace GLShader

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -71,6 +71,7 @@ OpenGLState::OpenGLState() {
     draw.vertex_buffer = 0;
     draw.uniform_buffer = 0;
     draw.shader_program = 0;
+    draw.program_pipeline = 0;
 
     scissor.enabled = false;
     scissor.x = 0;
@@ -282,6 +283,11 @@ void OpenGLState::Apply() const {
         glUseProgram(draw.shader_program);
     }
 
+    // Program pipeline
+    if (draw.program_pipeline != cur_state.draw.program_pipeline) {
+        glBindProgramPipeline(draw.program_pipeline);
+    }
+
     // Scissor test
     if (scissor.enabled != cur_state.scissor.enabled) {
         if (scissor.enabled) {
@@ -356,6 +362,13 @@ OpenGLState& OpenGLState::ResetSampler(GLuint handle) {
 OpenGLState& OpenGLState::ResetProgram(GLuint handle) {
     if (draw.shader_program == handle) {
         draw.shader_program = 0;
+    }
+    return *this;
+}
+
+OpenGLState& OpenGLState::ResetPipeline(GLuint handle) {
+    if (draw.program_pipeline == handle) {
+        draw.program_pipeline = 0;
     }
     return *this;
 }

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -128,6 +128,7 @@ public:
         GLuint vertex_buffer;    // GL_ARRAY_BUFFER_BINDING
         GLuint uniform_buffer;   // GL_UNIFORM_BUFFER_BINDING
         GLuint shader_program;   // GL_CURRENT_PROGRAM
+        GLuint program_pipeline; // GL_PROGRAM_PIPELINE_BINDING
     } draw;
 
     struct {
@@ -161,6 +162,7 @@ public:
     OpenGLState& ResetTexture(GLuint handle);
     OpenGLState& ResetSampler(GLuint handle);
     OpenGLState& ResetProgram(GLuint handle);
+    OpenGLState& ResetPipeline(GLuint handle);
     OpenGLState& ResetBuffer(GLuint handle);
     OpenGLState& ResetVertexArray(GLuint handle);
     OpenGLState& ResetFramebuffer(GLuint handle);

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -73,7 +73,7 @@ private:
     // OpenGL object IDs
     OGLVertexArray vertex_array;
     OGLBuffer vertex_buffer;
-    OGLShader shader;
+    OGLProgram shader;
 
     /// Display information for top and bottom screens respectively
     std::array<ScreenInfo, 2> screen_infos;


### PR DESCRIPTION
## Motivation

We currently have an ambiguous concept in our code: a "shader" (`OGLShader` class) represents a OpenGL program object, not a shader object. This works fine till now because we either use completely fixed program (hard-coded GLSL), or program where only the fragment shader is configurable. In this case there is a well-defined 1:1 mapping between shader source code and program objects. However with #3499 pending, we are going to decompile PICA vertex & geometry shaders to GLSL as well, which means the vertex shader and the geometry shader are also configurable, breaking the 1:1 mapping between program objects and shader source code.

This PR is extracted from the bulk change in #3499. It intends to redefine program resource and shader resource to match what they are in OpenGL, and to add a manager that can "mix" shader stages to form a new program.

## Separate shader objects (SSO)
To mix shader stages, the extension [ARB_separate_shader_objects](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_separate_shader_objects.txt) is used. Shader objects for each stage is linked to their own standalone program objects. These programs then attach to a pipeline object on drawing. 

Since it is an extension that is not guaranteed supported on all devices, a fallback path is also provided. In the fallback path, shader objects are not linked until being used. The linked programs are also cached to avoid relinking. 

## "Shader stage object"
A new concept "shader stage object" is introduced, which represents either a shader object, used for the fallback path, or a program object produced by linking a single shader object, used for the SSO path. This conceptual object is now what shader cache caches (instead of full programs)

## Shader generation & management model and interfaces

In this new code, gl_shader_manager manages most shader-related work, which were previously handled directly by the rasterizer. This manager exposes the following functions
 - `Use{Type}{Stage}Shader({ConfigurationType} config...)`
   These functions use config parameters to generate a shader stage object (or try to match one in the cache) and set it ready to use. The `{Stage}` can be `Vertex`, `Geometry` or `Fragment`, representing the three stages in a OpenGL program. `{Type}` specify what major rendering method is being used. For example, for vertex shader, there will be two types: `Trivial` for the old CPU shader emulation path and the vertex shader simply passes on the vertices; `Programmable` for new GPU shader emulation where the vertex shader is decompiled from PICA shader. `{ConfigurationType}` is a package enough for generate a new shader source for this type.
    Generally speaking, each `UseXXXShader` function invokes a corresponding cache manager object, which on cache miss calls a corresponding function in gl_shader_gen to get the source code to generate a new shader stage object.
 - `ApplyTo`
   This applies all shader programs previously set by `UseXXXShader` functions to a OpenGLState object. The caller can then `Apply` this state and start drawing using the shaders.

## Shader uniform interface

We only use two methods to communicate between shader program and main program: textures and interface blocks. Commonly, these two methods only needs a hard-coded binding point setting at the beginning, and don't require any more configuration to the shader/program objects afterwards. In fact, they can be directly set in shader source code with In-Shader Specification extension (ARB_shading_language_420pack). To avoid extension checking & fallback boilerplate, we still sets the binding manually, while conceptually considering it as a part of shader compilation/linkage process. Therefore the binding setting is integrated in the shader manager, right after a program object is generated. Here "Program object is generated" means either when a shader stage object is generated for the SSO path, or when the program is linked for the fallback path.

The binding setting is done by `SetShaderUniformBlockBindings` and `SetShaderSamplerBindings`. They each contains a list of uniform blocks / texture samples possibly used by all shader stages. Currently only one uniform block is there, but more will be added for GPU shader emulation.

## What is going to be added by glvtx after this PR
 - more shader source generation function to gl_shader_gen (possibly in multiple files if they are too long)
 - correspondingly more `UseXXXShader` functions in the manager, and more internal shader cache for each shader type.
 - gl_rasterizer calls more `UseXXXShader` functions to draw with GPU shader emulation.